### PR TITLE
Localization added: German

### DIFF
--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Localization/de-de.cfg
@@ -1,0 +1,44 @@
+Localization
+{
+	de-de
+	{
+		// ********** All Parts:
+		#LOC.aa_atomicage_manufacturer = PorkWorks
+	
+		// ********** Part: nuclearEngineKANDL
+
+		#LOC.aa_nuclearEngineKANDL_description = Nimm einen RTG, pumpe Treibstoff durch dessen heissen radioaktiven Kern, endend in einer Schubdüse. Das Resultat ist ein sehr kleiner Nuklearraketenantrieb. Der Schub ist gering, jedoch wird das Sonden nicht weiter stören. Abwärmeproduktion: 400 Einheiten.
+		#LOC.aa_nuclearEngineKANDL_title = LV-RTG "KANDL" SKALOU.v2 Radioisotopentriebwerk
+
+		// ********** Part: nuclearEngineLANTR
+
+		#LOC.aa_nuclearEngineLANTR_description = Ein ziemlich kompaktes und leichtes thermonukleares Raketendesign. Großartiges Merkmal: Ein Erweiterter LOX-Nachbrennermodus - Oxidiator wird direkt in die Schubdüse eingespritzt, wo es heftig mit dem extrem heissen Plasmaausstoß reagiert und einen starken Schubanstieg, zu Lasten niedrigerem Vakuumschub bewirkt. Abwärmeproduktion: 250 bzw. 500 Einheiten.
+		#LOC.aa_nuclearEngineLANTR_title = LV-Nx "LANTRN" Nukleartriebwerk
+
+		// ********** Part: nuclearEngineLightbulb
+
+		#LOC.aa_nuclearEngineLightbulb_description = Das Design eines geschlossenen Gaskreislaufkerns übertrifft die Limitierung herkömmlicher Festkern-Thermonuklearraketentriebwerke mittels bewusster Verdampfung des nuklearen Kerns mit dem Ergebnis höherer Kerntemperaturen und Ausstoßgeschwindigkeiten, was diesem Antrieb ein Vakuum-ISP von 1500 beschert. Es tritt kein radioaktives Material aus dem Antrieb aus, aber das gasförmige nukleare Höllenfeuer wird in sieben transparenten zerbrechlichen Quartzkolben gehalten, die allerdings nukleare Strahlung abgeben und dem Triebwerk den Beinamen "Glühbirne" verpassen. Ein ausgeklügeltes Kühlungssystem und eine stetige Wirbelströmung des umgebenden Gases sind notwendig, um das sich spaltende nukleare Plasma von Hüllenkontakt zu den Quartzkolben abzuhalten,was diese sofort verdampfen lassen würde. Klar, es klingt etwas gefährlich, aber wie mit Allem im Leben steigt die Coolness einer Sache propotional zu ihrer Gefährlichkeit. Abwärmeproduktion: 2000 Einheiten.
+		#LOC.aa_nuclearEngineLightbulb_title = CCGC-7.2 "Lightbulb" Nukleartriebwerk
+
+		// ********** Part: NuclearJetEngine
+
+		#LOC.aa_NuclearJetEngine_description = Vergleichbar mit einem chemisch basierten Turbojettriebwerk, mit Ausnahme der Verbrennungskammer, die gegen einen Nuklearreaktor getauscht wurde, um Luft zu erhitzen und die Turbine anzutreiben. Da das Triebwerk nicht auf chemischer Verbrennung basiert, ist die Flugzeit quasi unbegrenzt und es funktioniert auch in luftleerer Atmosphäre. Nachteil der Konstruktion ist das höhere Gewicht durch die Reaktorabschirmung.
+		#LOC.aa_NuclearJetEngine_tags = aktiv atom effizient antrieb triebwerk kerze nuklear nuke antrieb radio reaktor turbo jet
+		#LOC.aa_NuclearJetEngine_title = LV-Tx "Torch" Skalou-v5 Nukleares Turbojettriebwerk
+
+		// ********** Part: radiatorRadialLarge
+
+		#LOC.aa_radiatorRadialLarge_description = Hochleistungstitankühlköper mit Flüssig-Lithiumkühlkreislauf. Hochgradig temperaturresistent und robust. Leistungswertung: 300.
+		#LOC.aa_radiatorRadialLarge_title = Gebogener Kühlkörper (3.75m)
+
+		// ********** Part: radiatorRadialMedium
+
+		#LOC.aa_radiatorRadialMedium_description = Hochleistungstitankühlköper mit Flüssig-Lithiumkühlkreislauf. Hochgradig temperaturresistent und robust. Leistungswertung: 125.
+		#LOC.aa_radiatorRadialMedium_title = Gebogener Kühlkörper (2.5m)
+
+		// ********** Part: radiatorRadialSmall
+
+		#LOC.aa_radiatorRadialSmall_description = Hochleistungstitankühlköper mit Flüssig-Lithiumkühlkreislauf. Hochgradig temperaturresistent und robust. Leistungswertung: 60.
+		#LOC.aa_radiatorRadialSmall_title = Gebogener Kühlkörper (1.25m)
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Localization/en-us.cfg
@@ -1,0 +1,44 @@
+Localization
+{
+	en-us
+	{
+		// ********** All Parts:
+		#LOC.aa_atomicage_manufacturer = PorkWorks
+	
+		// ********** Part: nuclearEngineKANDL
+
+		#LOC.aa_nuclearEngineKANDL_description = Take an RTG, and pump fuel through the hot radioactive core into a nozzle. The result is a very small nuclear rocket engine. Thrust is low, but probes won't mind. Waste Heat Rating: 400
+		#LOC.aa_nuclearEngineKANDL_title = LV-RTG "KANDL" SKALOU.v2 Radioisotope Rocket
+
+		// ********** Part: nuclearEngineLANTR
+
+		#LOC.aa_nuclearEngineLANTR_description = A more compact and lightweight Nuclear Thermal Rocket design. Hot Feature: LOX-Augmented Afterburner mode - Oxidizer is injected directly into the nozzle where it violently reacts with the superheated plasma exhaust and causes a massive increase in thrust, at the cost of a lower ISP. Waste Heat Rating: 250/500
+		#LOC.aa_nuclearEngineLANTR_title = LV-Nx "LANTRN" Atomic Engine
+
+		// ********** Part: nuclearEngineLightbulb
+
+		#LOC.aa_nuclearEngineLightbulb_description = The Closed Cycle Gas-Core design overcomes the limits of Solid Core NTR's by deliberately letting the Reactor melt and vaporize, reaching much higher core temperatures and exhaust velocities, which grants this rocket an enoromous ISP of 1500s. No radioactive material leaves the engine though, the vaporized nuclear hellfire is safely confined within seven astonishingly fragile transparent quartz bulbs, which let most of the thermal radiation through to the propellant and are the reason for its lovely name. A sophisticated system of active cooling and a steady vortex stream of inert gas around the fissioning nuclear plasma that keeps it from touching the walls prevent the quartz bulbs from spontaneously vaporizing. Actually yes, it does sound kind of scary, but as with everything in life, the coolness of things is proportional to their danger. Waste Heat Rating: 2000
+		#LOC.aa_nuclearEngineLightbulb_title = CCGC-7.2 "Lightbulb" Atomic Engine
+
+		// ********** Part: NuclearJetEngine
+
+		#LOC.aa_NuclearJetEngine_description = Similiar to a chemical Turbojet, except the cumbustion chamber has been replaced by a nuclear reactor heating the air and driving the turbine. Since it does not rely on chemical combustion, flight time is unlimited and the engine will work in oxygenless atmospheres. The only downside is the mass added by the heavy reactor shielding.
+		#LOC.aa_NuclearJetEngine_tags = active atom efficient engine (torch nuclear nuke propuls radio reactor turbo jet
+		#LOC.aa_NuclearJetEngine_title = LV-Tx "Torch" Skalou-v5 Atomic Turbojet
+
+		// ********** Part: radiatorRadialLarge
+
+		#LOC.aa_radiatorRadialLarge_description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 300
+		#LOC.aa_radiatorRadialLarge_title = Wrap-Around Radiator (3.75m)
+
+		// ********** Part: radiatorRadialMedium
+
+		#LOC.aa_radiatorRadialMedium_description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 125
+		#LOC.aa_radiatorRadialMedium_title = Wrap-Around Radiator (2.5m)
+
+		// ********** Part: radiatorRadialSmall
+
+		#LOC.aa_radiatorRadialSmall_description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 60
+		#LOC.aa_radiatorRadialSmall_title = Wrap-Around Radiator (1.25m)
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/KANDL-2/KANDL-2.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/KANDL-2/KANDL-2.cfg
@@ -27,9 +27,9 @@ PART
 	cost = 5000
 	category = Engine
 	subcategory = 0
-	title = LV-RTG "KANDL" SKALOU.v2 Radioisotope Rocket//"Candle" Radioisotope Rocket//LV-RTG "KANDL" Radioisotope Rocket//************************
-	manufacturer = PorkWorks
-	description = Take an RTG, and pump fuel through the hot radioactive core into a nozzle. The result is a very small nuclear rocket engine. Thrust is low, but probes won't mind. Waste Heat Rating: 400
+	title = #LOC.aa_nuclearEngineKANDL_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_nuclearEngineKANDL_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0
@@ -49,7 +49,7 @@ PART
 	maxTemp = 2500
 	bulkheadProfiles = size0
 	
-	tags = probe #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum
+	tags = probe #autoLOC_500438
 	
 	EFFECTS
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/LANTR/LANTR.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/LANTR/LANTR.cfg
@@ -17,9 +17,9 @@ PART
 	cost = 11000
 	category = Engine
 	subcategory = 0
-	title = LV-Nx "LANTRN" Atomic Engine
-	manufacturer = PorkWorks
-	description = A more compact and lightweight Nuclear Thermal Rocket design. Hot Feature: LOX-Augmented Afterburner mode - Oxidizer is injected directly into the nozzle where it violently reacts with the superheated plasma exhaust and causes a massive increase in thrust, at the cost of a lower ISP. Waste Heat Rating: 250/500
+	title = #LOC.aa_nuclearEngineLANTR_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_nuclearEngineLANTR_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,1
@@ -44,7 +44,7 @@ PART
 	
 	bulkheadProfiles = size1
 	
-	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum
+	tags = #autoLOC_500438
 
 	EFFECTS
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Lightbulb-2/LightBulb-2.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Lightbulb-2/LightBulb-2.cfg
@@ -16,9 +16,9 @@ PART
 	cost = 56000
 	category = Engine
 	subcategory = 0
-	title = CCGC-7.2 "Lightbulb" Atomic Engine//************************
-	manufacturer = PorkWorks//************************ should change this? because its not findable in manufacturer categaory in VAB
-	description = The Closed Cycle Gas-Core design overcomes the limits of Solid Core NTR's by deliberately letting the Reactor melt and vaporize, reaching much higher core temperatures and exhaust velocities, which grants this rocket an enoromous ISP of 1500s. No radioactive material leaves the engine though, the vaporized nuclear hellfire is safely confined within seven astonishingly fragile transparent quartz bulbs, which let most of the thermal radiation through to the propellant and are the reason for its lovely name. A sophisticated system of active cooling and a steady vortex stream of inert gas around the fissioning nuclear plasma that keeps it from touching the walls prevent the quartz bulbs from spontaneously vaporizing. Actually yes, it does sound kind of scary, but as with everything in life, the coolness of things is proportional to their danger. Waste Heat Rating: 2000
+	title = #LOC.aa_nuclearEngineLightbulb_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_nuclearEngineLightbulb_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
@@ -39,7 +39,7 @@ PART
 
 	bulkheadProfiles = size2
 
-	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum
+	tags = #autoLOC_500438
 
 	EFFECTS
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialLarge.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialLarge.cfg
@@ -16,9 +16,9 @@ PART
 	cost = 1250
 	category = Thermal
 	subcategory = 0
-	title = Wrap-Around Radiator (3.75m)
-	manufacturer = PorkWorks
-	description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 300
+	title = #LOC.aa_radiatorRadialLarge_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_radiatorRadialLarge_description
 	attachRules = 0,1,0,1,1
 	mass = 0.075
 	thermalMassModifier = 1
@@ -44,7 +44,7 @@ maxTemp = 2500 // 2000
 	fuelCrossFeed = False
 
 	bulkheadProfiles = srf // size0, srf
-	tags = #autoLOC_500798 //#autoLOC_500798 = cool fixed heat moderat radiat static temperat therm
+	tags = #autoLOC_500798
 
 	MODULE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialMedium.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialMedium.cfg
@@ -16,9 +16,9 @@ PART
 	cost = 650
 	category = Thermal
 	subcategory = 0
-	title = Wrap-Around Radiator (2.5m)
-	manufacturer = PorkWorks
-	description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 125
+	title = #LOC.aa_radiatorRadialMedium_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_radiatorRadialMedium_description
 	attachRules = 0,1,0,1,1
 	mass =  0.045
 	thermalMassModifier = 1

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialSmall.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialSmall.cfg
@@ -16,9 +16,9 @@ PART
 	cost = 250
 	category = Thermal
 	subcategory = 0
-	title = Wrap-Around Radiator (1.25m)
-	manufacturer = PorkWorks
-	description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 60
+	title = #LOC.aa_radiatorRadialSmall_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_radiatorRadialSmall_description
 	attachRules = 0,1,0,1,1 
 	mass = 0.025
 	thermalMassModifier = 1

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Turbojet-5/TuboJet-5.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Turbojet-5/TuboJet-5.cfg
@@ -14,9 +14,10 @@ PART
 	cost = 1850
 	category = Engine
 	subcategory = 0
-	title = LV-Tx "Torch" Skalou-v5 Atomic Turbojet//"Torch" Nuclear Turbojet //************************
-	manufacturer = PorkWorks
-	description = Similiar to a chemical Turbojet, except the cumbustion chamber has been replaced by a nuclear reactor heating the air and driving the turbine. Since it does not rely on chemical combustion, flight time is unlimited and the engine will work in oxygenless atmospheres. The only downside is the mass added by the heavy reactor shielding.
+	title = #LOC.aa_NuclearJetEngine_title
+	manufacturer = #LOC.aa_atomicage_manufacturer
+	description = #LOC.aa_NuclearJetEngine_description
+	
 	attachRules = 1,1,1,1,0
 	mass = 8.25
 	// heatConductivity = 0.06 // half default

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/BahaSP/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/BahaSP/Localization/de-de.cfg
@@ -1,0 +1,12 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** Part: bahaMk2LightningCockpit
+
+		#LOC_bahaMk2LightningCockpit_description = Dies ist ein Zwei-Mann-Cockpit passend zu den MK2-Bauteilen von B9 Aerospace. Inspiriert von den Kampfjets F-35 und F-22. Das Modul verfügt über einen eingebauten Lufteinlass, komplette Innenansicht und ein großes gläsernes Kabinendach, durch das du alles um dich herum erkennen kannst. Hoffentlich hält es das Vakuum des Alls aus. Verfügbar mittels MFD sind Kameras nach vorne, für die Landung, zur Bombardierung und nach hinten.
+		#LOC_bahaMk2LightningCockpit_manufacturer = Bahamuto Dynamics
+		#LOC_bahaMk2LightningCockpit_title = MK2 Lightning Cockpit
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/BahaSP/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/BahaSP/Localization/en-us.cfg
@@ -1,0 +1,13 @@
+
+Localization
+{
+	en-us
+	{
+
+		// ********** Part: bahaMk2LightningCockpit
+
+		#LOC_bahaMk2LightningCockpit_description = This is a two-man cockpit made to fit well with the Mk2 parts from B9 Aerospace. Inspired by the F-35 and F-22, the module has built-in air intakes, a fully loaded IVA and a huge glass canopy. You'll be able to clearly see all around you. Just hope it can withstand the vacuum of space. Accessible through the MFDs are a forward, landing, bombing, and rear view camera.
+		#LOC_bahaMk2LightningCockpit_manufacturer = Bahamuto Dynamics
+		#LOC_bahaMk2LightningCockpit_title = MK2 Lightning Cockpit
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/BahaSP/Parts/mk2LightningCockpit/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/BahaSP/Parts/mk2LightningCockpit/part.cfg
@@ -25,9 +25,9 @@ PART
 	cost = 3000
 	category = Pods
 	subcategory = 0
-	title = MK2 Lightning Cockpit
-	manufacturer = Bahamuto Dynamics
-	description = This is a two-man cockpit made to fit well with the Mk2 parts from B9 Aerospace. Inspired by the F-35 and F-22, the module has built-in air intakes, a fully loaded IVA and a huge glass canopy. You'll be able to clearly see all around you. Just hope it can withstand the vacuum of space. Accessible through the MFDs are a forward, landing, bombing, and rear view camera.
+	title = #LOC_bahaMk2LightningCockpit_title
+	manufacturer = #LOC_bahaMk2LightningCockpit_manufacturer
+	description = #LOC_bahaMk2LightningCockpit_description
 	//attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
 

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Localization/de-de.cfg
@@ -1,0 +1,34 @@
+Localization
+{
+	de-de
+	{
+	
+		// ********** All Parts:	
+		#LOC.cw_clockwork_manufacturer = Clockwork Industries	
+
+		// ********** Part: AdapterfuelTank
+
+		#LOC.cw_AdapterfuelTank_description = Dieser Treibstofftank ist um 5 Grad seitwärts an der Oberseite angewinkelt, um angewinkelte Montagen zu ermöglichen. Es ist nicht ratsam, 36 von ihnen in einer grossen Schlange anzuordnen.
+		#LOC.cw_AdapterfuelTank_title = CW-AT40 5-Grad Treibstofftank
+
+		// ********** Part: CWRamAirIntake MK3
+
+		#LOC.cw_CWRamAirIntake MK3_description = Verbesserter Ram-Lufteinlass, um Luft bei extremen Geschwindigkeiten und großen Höhen aufzuheizen und zu komprimieren. Diese Modelle können bei 12.5% des Luftdrucks gegenüber Mitbewerbern arbeiten und das bei nur 40-fachem Gewicht.
+		#LOC.cw_CWRamAirIntake MK3_title = CW-RAI-003 Ram Lufteinlass & Kompressor MK3
+
+		// ********** Part: FifteenDegreeAdapterfuelTank
+
+		#LOC.cw_FifteenDegreeAdapterfuelTank_description = Dieser Treibstofftank ist um 15 Grad seitwärts an der Oberseite angewinkelt, um angewinkelte Montagen zu ermöglichen. Empfohlen wird die Montage von Shuttletriebwerken, nicht jedoch Tische, da von ihnen alles herunter rutschen würde... Riecht nach Raketentreibstoff.
+		#LOC.cw_FifteenDegreeAdapterfuelTank_title = CW-AT64 15-Grad Treibstofftank
+		// ********** Part: LargeFifteenDegreeAdapterfuelTank
+
+		#LOC.cw_LargeFifteenDegreeAdapterfuelTank_description = Dieser 2m-Durchmesser Treibstofftank ist um 15 Grad seitwärts an der Oberseite angewinkelt, um angewinkelte Montagen zu ermöglichen. Große Triebwerke können hier angebracht werden, kann auch zur Montage runder Raumstationen genutzt werden.
+		#LOC.cw_LargeFifteenDegreeAdapterfuelTank_title = CW-AT512 15-Grad Treibstofftank
+
+		// ********** Part: OxiTankSmallFlat
+
+		#LOC.cw_OxiTankSmallFlat_description = Ein kleiner Tank, nur mit Oxidator gefüllt. Dieser Tank wurde weitestgehend für Raumschiffe und Lebenserhaltungssysteme konstruiert.
+		#LOC.cw_OxiTankSmallFlat_tags = treibstoff treibstofftank sauer oxidator rakete
+		#LOC.cw_OxiTankSmallFlat_title = OX-C100 Oxidatortank
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Localization/en-us.cfg
@@ -1,0 +1,35 @@
+Localization
+{
+	en-us
+	{
+	
+		// ********** All Parts:	
+		#LOC.cw_clockwork_manufacturer = Clockwork Industries	
+
+		// ********** Part: AdapterfuelTank
+
+		#LOC.cw_AdapterfuelTank_description = This fuel tank has been angled sideways 5 degrees at the top to allow for angled attachment. It is not advised to attach thirty six of them in a giant snake.
+		#LOC.cw_AdapterfuelTank_title = CW-AT40 5-Degree FuelTank
+
+		// ********** Part: CWRamAirIntake MK3
+
+		#LOC.cw_CWRamAirIntake MK3_description = Upgraded Ram air intakes, used to superheat and compress air for engines at excessive speeds and altitudes. These Models can work at 12.5% the competitors air presssure and all for only 40 times the mass.
+		#LOC.cw_CWRamAirIntake MK3_title = CW-RAI-003 AirRam & Compressor Intake MK3
+
+		// ********** Part: FifteenDegreeAdapterfuelTank
+
+		#LOC.cw_FifteenDegreeAdapterfuelTank_description = This fuel tank has been angled sideways 15 degrees at the top to allow for angled attachment. Suggested uses include attaching shuttle engines but do not include tables as everything would slide off of them... and taste of rocket fuel.
+		#LOC.cw_FifteenDegreeAdapterfuelTank_title = CW-AT64 15 Degree FuelTank
+
+		// ********** Part: LargeFifteenDegreeAdapterfuelTank
+
+		#LOC.cw_LargeFifteenDegreeAdapterfuelTank_description = This two meter diameter fuel tank has been angled sideways 15 degrees at the top to allow for angled attachment. Large engines can be attached this way as well as being usable in circular station construction.
+		#LOC.cw_LargeFifteenDegreeAdapterfuelTank_title = CW-AT512 15 Degree FuelTank
+
+		// ********** Part: OxiTankSmallFlat
+
+		#LOC.cw_OxiTankSmallFlat_description = A small tank containing only Oxidizer. This tank was mostly designed for use with spaceplanes and life support systems.
+		#LOC.cw_OxiTankSmallFlat_tags = fueltank oxidizer propellant rocket
+		#LOC.cw_OxiTankSmallFlat_title = OX-C100 Oxidizer Tank
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Adapter_Tank/Five_Degree_Adapter_Tank.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Adapter_Tank/Five_Degree_Adapter_Tank.cfg
@@ -28,9 +28,9 @@ PART
 	cost = 320
 	category = FuelTank
 	subcategory = 0
-	title = CW-AT40 5-Degree FuelTank
-	manufacturer = Clockwork Industries
-	description = This fuel tank has been angled sideways 5 degrees at the top to allow for angled attachment. It is not advised to attach thirty six of them in a giant snake. 
+	title = #LOC.cw_AdapterfuelTank_title
+	manufacturer = #LOC.cw_clockwork_manufacturer
+	description = #LOC.cw_AdapterfuelTank_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,1
@@ -47,7 +47,7 @@ PART
 	maxTemp = 2000
 
 	bulkheadProfiles = size1, srf
-	tags = #autoLOC_500534 //#autoLOC_500534 = fueltank ?lfo liquid oxidizer propellant rocket
+	tags = #autoLOC_500534
 	
 	RESOURCE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Fifteen_Deg_Adapter/Fifteen_Deg_Adpt.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Fifteen_Deg_Adapter/Fifteen_Deg_Adpt.cfg
@@ -24,13 +24,13 @@ PART
 	
 	// --- editor parameters ---
 	TechRequired = advRocketry
-	entryCost = 3200
-	cost = 600
+	entryCost = 2200
+	cost = 440
 	category = FuelTank
 	subcategory = 0
-	title = CW-AT64 15 Degree FuelTank
-	manufacturer = Clockwork Industries
-	description = This fuel tank has been angled sideways 15 degrees at the top to allow for angled attachment. Suggested uses include attaching shuttle engines but do not include tables as everything would slide off of them... and taste of rocket fuel.
+	title = #LOC.cw_FifteenDegreeAdapterfuelTank_title
+	manufacturer = #LOC.cw_clockwork_manufacturer
+	description = #LOC.cw_FifteenDegreeAdapterfuelTank_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,1
@@ -47,7 +47,7 @@ PART
 	maxTemp = 2000
 
 	bulkheadProfiles = size1, srf
-	tags = #autoLOC_500534 //#autoLOC_500534 = fueltank ?lfo liquid oxidizer propellant rocket
+	tags = #autoLOC_500534
 	
 	RESOURCE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Large_Fifteen_Deg_Adpt/Large_Fifteen_Deg_Adpt.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Large_Fifteen_Deg_Adpt/Large_Fifteen_Deg_Adpt.cfg
@@ -28,9 +28,9 @@ PART
 	cost = 600
 	category = FuelTank
 	subcategory = 0
-	title = CW-AT512 15 Degree FuelTank
-	manufacturer = Clockwork Industries
-	description = This two meter diameter fuel tank has been angled sideways 15 degrees at the top to allow for angled attachment. Large engines can be attached this way as well as being usable in circular station construction.
+	title = #LOC.cw_LargeFifteenDegreeAdapterfuelTank_title
+	manufacturer = #LOC.cw_clockwork_manufacturer
+	description = #LOC.cw_LargeFifteenDegreeAdapterfuelTank_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,1
@@ -47,7 +47,7 @@ PART
 	maxTemp = 2000
 
 	bulkheadProfiles = size2, srf
-	tags = #autoLOC_500534 //#autoLOC_500534 = fueltank ?lfo liquid oxidizer propellant rocket
+	tags = #autoLOC_500534
 	
 	RESOURCE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Oxidiser_Store/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/Oxidiser_Store/part.cfg
@@ -20,9 +20,9 @@ PART {
 	cost = 250
 	category = FuelTank
 	subcategory = 0
-	title = OX-C100 Oxidizer Tank
-	manufacturer = Clockwork Industries
-	description = A small tank containing only Oxidizer. This tank was mostly designed for use with spaceplanes and life support systems.
+	title = #LOC.cw_OxiTankSmallFlat_title
+	manufacturer = #LOC.cw_clockwork_manufacturer
+	description = #LOC.cw_OxiTankSmallFlat_description
 	
 	attachRules = 1,1,1,1,0
 	
@@ -37,7 +37,7 @@ PART {
 	breakingTorque = 50
 
 	bulkheadProfiles = size1, srf
-	tags = fueltank oxidizer propellant rocket
+	tags = #LOC.cw_OxiTankSmallFlat_tags
 	
 	RESOURCE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/RamAirIntakeMK3/Air_Ram_MK3.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Clockwork_Industries/Spare_Parts/Parts/RamAirIntakeMK3/Air_Ram_MK3.cfg
@@ -30,9 +30,10 @@ PART
 	cost = 16080		
 	category = Aero
 	subcategory = 0
-	title = CW-RAI-003 AirRam & Compressor Intake MK3
-	manufacturer = Clockwork Aerospace.
-	description = Upgraded Ram air intakes, used to superheat and compress air for engines at excessive speeds and altitudes. These Models can work at 12.5% the competitors air presssure and all for only 40 times the mass.
+	title = #LOC.cw_CWRamAirIntake MK3_title
+	manufacturer = #LOC.cw_clockwork_manufacturer
+	description = #LOC.cw_CWRamAirIntake MK3_description
+	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
 	stackSymmetry = 2
@@ -48,7 +49,7 @@ PART
 	fuelCrossFeed = True
 	
 	bulkheadProfiles = size2
-	tags = #autoLOC_500204 //#autoLOC_500204 = aero (air aircraft breathe cone fligh inlet jet oxygen plane suck supersonic
+	tags = #autoLOC_500204
 	
 	// ----- DO NOT EDIT BELOW THIS POINT ------
 	

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/KAL9000/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/KAL9000/Localization/de-de.cfg
@@ -1,0 +1,13 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** Part: KAL9000
+
+		#LOC_KAL9000_description = Eine "Bring an, wo du willst" Kommandoeinheit. Neigt zu mörderischen Episoden. Gut geeignet für zweite Stufen mit Nutzlast oder was auch immer du kontrollieren möchtest. Kein Reaktionsrad, reagiert sensibel auf negative Bemerkungen über sein einzelnes rotes Auge!
+		#LOC_KAL9000_manufacturer = NAU Aerospace
+		#LOC_KAL9000_tags = cmg kommando kontrol (kern fliegen flug kerbnet moment sonde sas satellit weltall stab steuer
+		#LOC_KAL9000_title = NAU KAL9000
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/KAL9000/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/KAL9000/Localization/en-us.cfg
@@ -1,0 +1,13 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** Part: KAL9000
+
+		#LOC_KAL9000_description = A "stick it where you like it" command unit, prone to homicidal episodes, good to attach on secondary payloads or whatever you want to control. No reaction wheel, sensitive to bad remarks about it's single red eye!
+		#LOC_KAL9000_manufacturer = NAU Aerospace
+		#LOC_KAL9000_tags = cmg command control (core fly kerbnet moment probe sas satellite space stab steer
+		#LOC_KAL9000_title = NAU KAL9000
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/KAL9000/Parts/KAL9000/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/KAL9000/Parts/KAL9000/part.cfg
@@ -3,26 +3,26 @@ PART
 	name = KAL9000
 	module = Part
 	author = IGNOBIL
-	
+
 	mesh = model.mu
 	scale = 0.1
-	
+
 	CrewCapacity = 0
-	
+
 	node_stack_bottom = 0, 0, 0, 0.0, 1.0, 0.0
 	node_attach = 0, 0, 0, 0.0, -1.0, 0.0, 1
-	
+
 	TechRequired = unmannedTech
-	entryCost = 5000
+	entryCost = 2500
 	cost = 480
 	category = Pods
 	subcategory = 0
-	title = NAU KAL9000
-	manufacturer = NAU Aerospace
-	description = A "stick it where you like it" command unit, prone to homicidal episodes, good to attach on secondary payloads or whatever you want to control. No reaction wheel, sensitive to bad remarks about it's single red eye!
-	
+	title = #LOC_KAL9000_title
+	manufacturer = #LOC_KAL9000_manufacturer
+	description = #LOC_KAL9000_description
+
 	attachRules = 1,1,1,0,0
-	
+
 	mass = 0.02
 	dragModelType = default
 	maximum_drag = 0.1
@@ -30,44 +30,42 @@ PART
 	angularDrag = 0.5
 	crashTolerance = 12
 	maxTemp = 1200
-	
+
 	explosionPotential = 0
-	
+
 	vesselType = Probe
 
-	tags = cmg command control (core fly kerbnet moment probe sas satellite space stab steer 
-	
+	tags = #KAL9000_tags
+
 	MODULE
 	{
 		name = ModuleCommand
 		minimumCrew = 0
-		
+
 		RESOURCE
 		{
 			name = ElectricCharge
 			rate = 0.01
 		}
 	}
-	
 	RESOURCE
 	{
 		name = ElectricCharge
 		amount = 10
 		maxAmount = 10
 	}
-
 	MODULE
 	{
 		name = ModuleKerbNetAccess
 		MinimumFoV = 21
 		MaximumFoV = 54
 		AnomalyDetection = 0.06
+
 		DISPLAY_MODES
 		{
-			Mode = Terrain,#autoLOC_438839 //#autoLOC_438839 = Terrain
+			Mode = Terrain,#autoLOC_438839
 		}
 	}
-
 	MODULE
 	{
 		name = ModuleDataTransmitter
@@ -80,6 +78,5 @@ PART
 		optimumRange = 2500
 		packetFloor = .1
 		packetCeiling = 5
-	}	
-	
+	}
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/LV2N.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/LV2N.cfg
@@ -22,7 +22,7 @@ PART
 	// -------- FX -------- 
 	
 	fx_exhaustFlame_blue = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, running
-fx_exhaustLight_blue = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, running
+	fx_exhaustLight_blue = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, running
 	fx_smokeTrail_light = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, running
 	
 	sound_vent_medium = engage
@@ -33,14 +33,14 @@ fx_exhaustLight_blue = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, running
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 25900
-	cost = 16000
+	entryCost = 60900
+	cost = 20500
 
 	category = Propulsion
 	subcategory = 0
-	title = LV-2N
-	manufacturer = Jebediah Kerman's Junkyard and Spacecraft Parts Co
-	description = Sometimes a single LV-N just dosn't provide enough thrust. 
+	title = #LOC.lvn_lv2n_title
+	manufacturer = #LOC.lvn_lv2n_manufacturer
+	description = #LOC.lvn_lv2n_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/LV4N.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/LV4N.cfg
@@ -33,14 +33,14 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 35200
-	cost = 30000
+	entryCost = 125000
+	cost = 38000
 	
 	category = Propulsion
 	subcategory = 0
-	title = LV-4N
-	manufacturer = Jebediah Kerman's Junkyard and Spacecraft Parts Co
-	description = When tasked with providing an atomic propulsion solution for high thrust applications engineers did the only sensible thing: strap four enlarged LV-N reactors together.
+	title = #LOC.lvn_lv4n_title
+	manufacturer = #LOC.lvn_lv2n_manufacturer
+	description = #LOC.lvn_lv4n_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/Localization/de-de.cfg
@@ -14,7 +14,7 @@ Localization
 
 		// ********** Part: lv4n
 
-		#LOC.lvn_lv4n_description = Wenn der Auftrag lautet, eine Nuklearantriebslösung mit hohem Schub zu finden, machen Ingeneure das einzig Richtige: Sie schnallen vier LV-N Reaktoren zusammen.
+		#LOC.lvn_lv4n_description = Wenn der Auftrag lautet, eine Nuklearantriebslösung mit hohem Schub zu finden, machen Ingenieure das einzig Richtige: Sie schnallen vier LV-N Reaktoren zusammen.
 		#LOC.lvn_lv4n_title = LV-4N Nukleartriebwerk
 
 	}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/Localization/de-de.cfg
@@ -1,0 +1,21 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** All Parts:
+		#LOC.lvn_lv2n_manufacturer = Jebediah Kerman's Junkyard and Spacecraft Parts Co
+		
+		
+		// ********** Part: lv2n
+
+		#LOC.lvn_lv2n_description = Manchmal bringt eine einzelne LV-N einfach nicht genug Schub.
+		#LOC.lvn_lv2n_title = LV-2N Nukleartriebwerk
+
+		// ********** Part: lv4n
+
+		#LOC.lvn_lv4n_description = Wenn der Auftrag lautet, eine Nuklearantriebslösung mit hohem Schub zu finden, machen Ingeneure das einzig Richtige: Sie schnallen vier LV-N Reaktoren zusammen.
+		#LOC.lvn_lv4n_title = LV-4N Nukleartriebwerk
+
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/LVN_Clusters/Localization/en-us.cfg
@@ -1,0 +1,21 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** All Parts:
+		#LOC.lvn_lv2n_manufacturer = Jebediah Kerman's Junkyard and Spacecraft Parts Co
+		
+		
+		// ********** Part: lv2n
+
+		#LOC.lvn_lv2n_description = Sometimes a single LV-N just dosn't provide enough thrust.
+		#LOC.lvn_lv2n_title = LV-2N Nuclear Rocket
+
+		// ********** Part: lv4n
+
+		#LOC.lvn_lv4n_description = When tasked with providing an atomic propulsion solution for high thrust applications engineers did the only sensible thing: strap four enlarged LV-N reactors together.
+		#LOC.lvn_lv4n_title = LV-4N Nuclear Rocket
+
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Localization/de-de.cfg
@@ -1,0 +1,22 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** All Parts:
+		#LOC.mk2con_manufacturer = C7 Aerospace Division		
+		#LOC.mk2con_tags = KIS container inventar tragbar cck-container mk2 Konstruktion
+	
+	
+		// ********** Part: MK2Cont8
+
+		#LOC.mk2con_MK2Cont8_description = Mk2 KIS-Container mit 8000L Kapazität
+		#LOC.mk2con_MK2Cont8_title = Mk2 KIS-Container 8000L
+
+		// ********** Part: MK2Cont4
+
+		#LOC.mk2con_MK2Cont4_description = Mk2 KIS-Container mit 4000L Kapazität
+		#LOC.mk2con_MK2Cont4_title = Mk2 KIS-Container 4000L
+
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Localization/en-us.cfg
@@ -1,0 +1,22 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** All Parts:
+		#LOC.mk2con_manufacturer = C7 Aerospace Division		
+		#LOC.mk2con_tags = KIS container inventory portable cck-containers mk2
+	
+	
+		// ********** Part: mk2Battery
+
+		#LOC.mk2con_MK2Cont8_description = Mk2 KIS Container with 8000L capacity
+		#LOC.mk2con_MK2Cont8_title = Mk2 KIS Container 8000L
+
+		// ********** Part: MK2Cont4
+
+		#LOC.mk2con_MK2Cont4_description = Mk2 KIS Container with 4000L capacity
+		#LOC.mk2con_MK2Cont4_title = Mk2 KIS Container 4000L
+
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Parts/MK2Cont4.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Parts/MK2Cont4.cfg
@@ -19,10 +19,9 @@ PART
 	cost = 2000
 	category = Payload
 	subcategory = 0
-	title = Mk2 KIS Container 4000L
-	tags = mk2 container kis inventory cck-containers
-	manufacturer = C7 Aerospace Division
-	description = Mk2 KIS Container 4000L
+	title = #LOC.mk2con_MK2Cont4_title
+	manufacturer = #LOC.mk2con_manufacturer
+	description = #LOC.mk2con_MK2Cont4_description
 	attachRules = 1,1,1,1,0
 	mass = 0.25
 	dragModelType = default
@@ -37,7 +36,7 @@ PART
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
 
-	tags = KIS container inventory portable cck-containers
+	tags = #LOC.mk2con_tags
 
 	MODULE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Parts/MK2Cont8.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Containers/Parts/MK2Cont8.cfg
@@ -19,10 +19,9 @@ PART
 	cost = 4000
 	category = Payload
 	subcategory = 0
-	title = Mk2 KIS Container 8000L
-	tags = mk2 container kis inventory cck-containers
-	manufacturer = C7 Aerospace Division
-	description = Mk2 KIS Container 8000L
+	title = #LOC.mk2con_MK2Cont8_title
+	manufacturer = #LOC.mk2con_manufacturer
+	description = #LOC.mk2con_MK2Cont8_description
 	attachRules = 1,1,1,1,0
 	mass = 0.5
 	dragModelType = default
@@ -37,7 +36,7 @@ PART
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
 
-	tags = KIS container inventory portable cck-containers
+	tags = #LOC.mk2con_tags
 
 	MODULE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/Localization/de-de.cfg
@@ -5,32 +5,32 @@ Localization
 
 		// ********** Part: mk2Battery
 
-		#LOC.mk2ess_mk2Battery_description = Die Mk2 Batterie ist eine stapelbarer Akkukasten im Mk2-Format mit zehn Mal größerer Kapazität des Z-100.
+		#LOC.mk2ess_mk2Battery_description = Die Mk2 Batterie ist ein stapelbarer Akkukasten im Mk2-Format mit zehn Mal größerer Kapazität des Z-100.
 		#LOC.mk2ess_mk2Battery_manufacturer = Zaltonic Electronics
 		#LOC.mk2ess_mk2Battery_title = Mk2 Batterie
 
 		// ********** Part: mk2BatteryAlt
 
-		#LOC.mk2ess_mk2BatteryAlt_description = Die Mk2 Batterie ist eine stapelbarer Akkukasten im Mk2-Format mit zehn Mal größerer Kapazität des Z-100. Farbig kodierte Version.
+		#LOC.mk2ess_mk2BatteryAlt_description = Die Mk2 Batterie ist ein stapelbarer Akkukasten im Mk2-Format mit zehn Mal größerer Kapazität des Z-100. Farbig kodierte Version.
 		#LOC.mk2ess_mk2BatteryAlt_manufacturer = Zaltonic Electronics
 		#LOC.mk2ess_mk2BatteryAlt_title = Mk2 Batterie, farbig
 		
 		// ********** Part: mk2Decoupler
 
-		#LOC.mk2ess_mk2Decoupler_description = Der Mk2 Entkoppler ist mit (hoffentlich) kleinen Sprengbolzen ausgestattet, welche an ihm befestigte Strukturen trennen. Seitlich aufgebrachte Pfeile zeigen an, welches Teil abgesprengt wird.
+		#LOC.mk2ess_mk2Decoupler_description = Der Mk2 Entkoppler ist mit (hoffentlich) kleinen Sprengbolzen ausgestattet, welche an ihm befestigte Strukturen trennen. Seitlich angebrachte Pfeile zeigen an, welches Teil abgesprengt wird.
 		#LOC.mk2ess_mk2Decoupler_manufacturer = O.M.B. Demolition Enterprises
 		#LOC.mk2ess_mk2Decoupler_tags = m2x mk2 bruch spreng entkoppel separat teilen stufe
 		#LOC.mk2ess_mk2Decoupler_title = Mk2 Entkoppler
 
 		// ********** Part: mk2SAS
 
-		#LOC.mk2ess_mk2SAS_description = Wegen der großen Beliebtheit des verbesserten Reaktionsrad-Moduls, hat STEADLER Engineering Corps eine modifizierte, dem Mk2-Design angepasste Version entworfen.
+		#LOC.mk2ess_mk2SAS_description = Wegen der großen Beliebtheit des verbesserten Reaktionsrad-Moduls hat STEADLER Engineering Corps eine modifizierte, dem Mk2-Design angepasste Version entworfen.
 		#LOC.mk2ess_mk2SAS_manufacturer = STEADLER Engineering Corps
 		#LOC.mk2ess_mk2SAS_title = Mk2 verbessertes Reaktionsrad-Modul
 
 		// ********** Part: mk2Separator
 
-		#LOC.mk2ess_mk2Separator_description = Im Gegensatz zu Entkopplern trennen Separatoren alles ab, das an ihnen befestigt ist. Diese neue Technologie stieß bei Raketeningeneuren weltweit auf Begeisterung. Nicht übel für etwas, das als fehlgeschlagener Test eines Sprengbolzen-Prototypen angefangen hat.
+		#LOC.mk2ess_mk2Separator_description = Im Gegensatz zu Entkopplern trennen Separatoren alles ab, das an ihnen befestigt ist. Diese neue Technologie stieß bei Raketeningenieuren weltweit auf Begeisterung. Nicht übel für etwas, das als fehlgeschlagener Test eines Sprengbolzen-Prototypen angefangen hat.
 		#LOC.mk2ess_mk2Separator_manufacturer = O.M.B. Demolition Enterprises
 		#LOC.mk2ess_mk2Separator_tags = m2x mk2 bruch entkoppel separat teilen stufe
 		#LOC.mk2ess_mk2Separator_title = Mk2 Stapel-Separator

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/Localization/de-de.cfg
@@ -1,0 +1,39 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** Part: mk2Battery
+
+		#LOC.mk2ess_mk2Battery_description = Die Mk2 Batterie ist eine stapelbarer Akkukasten im Mk2-Format mit zehn Mal größerer Kapazität des Z-100.
+		#LOC.mk2ess_mk2Battery_manufacturer = Zaltonic Electronics
+		#LOC.mk2ess_mk2Battery_title = Mk2 Batterie
+
+		// ********** Part: mk2BatteryAlt
+
+		#LOC.mk2ess_mk2BatteryAlt_description = Die Mk2 Batterie ist eine stapelbarer Akkukasten im Mk2-Format mit zehn Mal größerer Kapazität des Z-100. Farbig kodierte Version.
+		#LOC.mk2ess_mk2BatteryAlt_manufacturer = Zaltonic Electronics
+		#LOC.mk2ess_mk2BatteryAlt_title = Mk2 Batterie, farbig
+		
+		// ********** Part: mk2Decoupler
+
+		#LOC.mk2ess_mk2Decoupler_description = Der Mk2 Entkoppler ist mit (hoffentlich) kleinen Sprengbolzen ausgestattet, welche an ihm befestigte Strukturen trennen. Seitlich aufgebrachte Pfeile zeigen an, welches Teil abgesprengt wird.
+		#LOC.mk2ess_mk2Decoupler_manufacturer = O.M.B. Demolition Enterprises
+		#LOC.mk2ess_mk2Decoupler_tags = m2x mk2 bruch spreng entkoppel separat teilen stufe
+		#LOC.mk2ess_mk2Decoupler_title = Mk2 Entkoppler
+
+		// ********** Part: mk2SAS
+
+		#LOC.mk2ess_mk2SAS_description = Wegen der großen Beliebtheit des verbesserten Reaktionsrad-Moduls, hat STEADLER Engineering Corps eine modifizierte, dem Mk2-Design angepasste Version entworfen.
+		#LOC.mk2ess_mk2SAS_manufacturer = STEADLER Engineering Corps
+		#LOC.mk2ess_mk2SAS_title = Mk2 verbessertes Reaktionsrad-Modul
+
+		// ********** Part: mk2Separator
+
+		#LOC.mk2ess_mk2Separator_description = Im Gegensatz zu Entkopplern trennen Separatoren alles ab, das an ihnen befestigt ist. Diese neue Technologie stieß bei Raketeningeneuren weltweit auf Begeisterung. Nicht übel für etwas, das als fehlgeschlagener Test eines Sprengbolzen-Prototypen angefangen hat.
+		#LOC.mk2ess_mk2Separator_manufacturer = O.M.B. Demolition Enterprises
+		#LOC.mk2ess_mk2Separator_tags = m2x mk2 bruch entkoppel separat teilen stufe
+		#LOC.mk2ess_mk2Separator_title = Mk2 Stapel-Separator
+
+		}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/Localization/en-us.cfg
@@ -1,0 +1,39 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** Part: mk2Battery
+
+		#LOC.mk2ess_mk2Battery_description = The Mk2 Battery is a stackable battery bank, with ten times the power capacity of the Z-100.
+		#LOC.mk2ess_mk2Battery_manufacturer = Zaltonic Electronics
+		#LOC.mk2ess_mk2Battery_title = Mk2 Battery
+
+		// ********** Part: mk2BatteryAlt
+
+		#LOC.mk2ess_mk2BatteryAlt_description = The Mk2-ALT Battery is a stackable battery bank, with ten times the power capacity of the Z-100.
+		#LOC.mk2ess_mk2BatteryAlt_manufacturer = Zaltonic Electronics
+		#LOC.mk2ess_mk2BatteryAlt_title = Mk2-ALT Battery
+
+		// ********** Part: mk2Decoupler
+
+		#LOC.mk2ess_mk2Decoupler_description = The Mk2 Stack Decoupler is equipped with a (hopefully) small explosive charge, that will sever the structural linkage between itself and whatever it's connected to. Painted on its sides are handy arrows indicating which side will detach.
+		#LOC.mk2ess_mk2Decoupler_manufacturer = O.M.B. Demolition Enterprises
+		#LOC.mk2ess_mk2Decoupler_tags = m2x mk2 break decouple separat split stag
+		#LOC.mk2ess_mk2Decoupler_title = Mk2 Stack Decoupler
+
+		// ********** Part: mk2SAS
+
+		#LOC.mk2ess_mk2SAS_description = Due to the popularity of the large Advanced Reaction Wheel Module, STEADLER Engineering Corps have modified the design to match the Mk2 form factor.
+		#LOC.mk2ess_mk2SAS_manufacturer = STEADLER Engineering Corps
+		#LOC.mk2ess_mk2SAS_title = Mk2 Advanced Reaction Wheel Module
+
+		// ********** Part: mk2Separator
+
+		#LOC.mk2ess_mk2Separator_description = Unlike Decouplers, Separators jettison everything attached to them. This new technology was very well received by rocket engineers everywhere. Not bad for something that started out as a failure for a controlled explosive bolt prototype.
+		#LOC.mk2ess_mk2Separator_manufacturer = O.M.B. Demolition Enterprises
+		#LOC.mk2ess_mk2Separator_tags = m2x mk2 break decouple separat split stag
+		#LOC.mk2ess_mk2Separator_title = Mk2 Stack Separator
+
+		}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Battery/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Battery/part.cfg
@@ -3,30 +3,26 @@ PART
 	name = mk2Battery
 	module = Part
 	author = J.Patrick
-	
+
 	// mesh = model.mu
-	MODEL
-	{
-		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Battery/model
-	}
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top = 0, 0.125, 0, 0.0, 1.0, 0.0
 	node_stack_bottom = 0, -0.125,0, 0.0, -1.0, 0.0
-	
+
 	// --- editor parameters ---
 	TechRequired = largeElectrics
 	entryCost = 8350
 	cost = 940
 	category = Electrical
 	subcategory = 0
-	title = Mk2 Battery
-	manufacturer = Zaltonic Electronics
-	description = The Mk2 Battery is a stackable battery bank, with ten times the power capacity of the Z-100.
+	title = #LOC.mk2ess_mk2Battery_title
+	manufacturer = #LOC.mk2ess_mk2Battery_manufacturer
+	description = #LOC.mk2ess_mk2Battery_description
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
-	
+
 	// --- standard part parameters ---
 	mass = 0.05
 	dragModelType = default
@@ -40,8 +36,12 @@ PART
 
 	bulkheadProfiles = mk2
 
-	tags = #autoLOC_500393 //#autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
-	
+	tags = #autoLOC_500393 // #autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
+
+	MODEL
+	{
+		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Battery/model
+	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2BatteryAlt/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2BatteryAlt/part.cfg
@@ -1,33 +1,29 @@
-	PART
-	{
+PART
+{
 	name = mk2BatteryAlt
 	module = Part
 	author = J.Patrick
-	
-	//mesh = model.mu
-	MODEL
-	{
-		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2BatteryAlt/model
-	}
+
+	// mesh = model.mu
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top = -0.015, 0.185, -0.15, 0.0, 1.0, 0.0
 	node_stack_bottom = -0.015, -0.065, -0.15, 0.0, -1.0, 0.0
-	
+
 	// --- editor parameters ---
 	TechRequired = largeElectrics
 	entryCost = 8350
 	cost = 940
 	category = Electrical
 	subcategory = 0
-	title = Mk2-ALT Battery
-	manufacturer = Zaltonic Electronics
-	description = The Mk2-ALT Battery is a stackable battery bank, with ten times the power capacity of the Z-100.
-	
+	title = #LOC.mk2ess_mk2BatteryAlt_title
+	manufacturer = #LOC.mk2ess_mk2BatteryAlt_manufacturer
+	description = #LOC.mk2ess_mk2BatteryAlt_description
+
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
-	
+
 	// --- standard part parameters ---
 	mass = 0.05
 	dragModelType = default
@@ -41,8 +37,12 @@
 
 	bulkheadProfiles = mk2
 
-	tags = #autoLOC_500393 //#autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
-	
+	tags = #autoLOC_500393 // #autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
+
+	MODEL
+	{
+		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2BatteryAlt/model
+	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Decoupler/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Decoupler/part.cfg
@@ -3,31 +3,27 @@ PART
 	name = mk2Decoupler
 	module = Part
 	author = J.Patrick
-	
-	//mesh = model.mu
-	MODEL
-	{
-		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Decoupler/model
-	}
+
+	// mesh = model.mu
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top = -0.015, 0.185, -0.15, 0.0, 1.0, 0.0
 	node_stack_bottom = -0.015, -0.065, -0.15, 0.0, -1.0, 0.0
-	
+
 	// --- editor parameters ---
 	TechRequired = basicRocketry
 	entryCost = 1200 // 1500
 	cost = 400 // 700
 	category = Coupling
 	subcategory = 0
-	title = Mk2 Stack Decoupler
-	manufacturer = O.M.B. Demolition Enterprises
-	description = The Mk2 Stack Decoupler is equipped with a (hopefully) small explosive charge, that will sever the structural linkage between itself and whatever it's connected to. Painted on its sides are handy arrows indicating which side will detach.
+	title = #LOC.mk2ess_mk2Decoupler_title
+	manufacturer = #LOC.mk2ess_mk2Decoupler_manufacturer
+	description = #LOC.mk2ess_mk2Decoupler_description
 	bulkheadProfiles = mk2
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
-	
+
 	// --- standard part parameters ---
 	mass = 0.075
 	dragModelType = default
@@ -39,16 +35,20 @@ PART
 	breakingTorque = 200
 	maxTemp = 2000 // 3400
 	fuelCrossFeed = False
-	
+
 	stageOffset = 1
 	childStageOffset = 1
-	
-	tags = m2x mk2 break decouple separat split stag
-	
+
+	tags = #LOC.mk2ess_mk2Decoupler_tags
+
+	MODEL
+	{
+		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Decoupler/model
+	}
 	MODULE
 	{
-	    name = ModuleDecouple
-	    ejectionForce = 250
+		name = ModuleDecouple
+		ejectionForce = 250
 		explosiveNodeID = top
 	}
 	MODULE
@@ -57,6 +57,7 @@ PART
 		useStaging = True
 		useEvent = False
 		situationMask = 127
+
 		CONSTRAINT
 		{
 			type = REPEATABILITY

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2SAS/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2SAS/part.cfg
@@ -1,30 +1,26 @@
-	PART
-	{
+PART
+{
 	name = mk2SAS
 	module = Part
 	author = J.Patrick
-	
-	//mesh = model.mu
-	MODEL
-	{
-		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2SAS/model
-	}
+
+	// mesh = model.mu
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top = 0.0, 0.125, 0, 0.0, 1.0, 0.0
 	node_stack_bottom = 0.0, -0.125, 0, 0.0, -1.0, 0.0
-	
+
 	TechRequired = specializedControl
 	entryCost = 12000
 	cost = 1800
 	category = Control
 	subcategory = 0
-	title = Mk2 Advanced Reaction Wheel Module
-	manufacturer = STEADLER Engineering Corps
-	description = Due to the popularity of the large Advanced Reaction Wheel Module, STEADLER Engineering Corps have modified the design to match the Mk2 form factor.
+	title = #LOC.mk2ess_mk2SAS_title
+	manufacturer = #LOC.mk2ess_mk2SAS_manufacturer
+	description = #LOC.mk2ess_mk2SAS_description
 	attachRules = 1,0,1,1,0
-	
+
 	mass = 0.2
 	dragModelType = default
 	maximum_drag = 0.2
@@ -34,22 +30,25 @@
 	maxTemp = 2000 // 3400
 
 	bulkheadProfiles = mk2
-	
-	tags = #autoLOC_500288 //#autoLOC_500288 = cmg command control fly gyro moment react stab steer torque
 
+	tags = #autoLOC_500288 // #autoLOC_500288 = cmg command control fly gyro moment react stab steer torque
+
+	MODEL
+	{
+		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2SAS/model
+	}
 	MODULE
 	{
 		name = ModuleReactionWheel
-		
+
 		PitchTorque = 20
 		YawTorque = 20
 		RollTorque = 20
-		
+
 		RESOURCE
 		{
 			name = ElectricCharge
 			rate = 0.5
 		}
 	}
-	
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Separator/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Separator/part.cfg
@@ -3,38 +3,34 @@ PART
 	name = mk2Separator
 	module = Part
 	author = J.Patrick
-	
-	//mesh = model.mu
-	MODEL
-	{
-		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Separator/model
-	}
+
+	// mesh = model.mu
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top = -0.015, 0.185, -0.15, 0.0, 1.0, 0.0
 	node_stack_bottom = -0.015, -0.065, -0.15, 0.0, -1.0, 0.0
-	
-	
+
+
 	// --- FX definitions ---
-	
+
 	fx_gasBurst_white = 0.0, 0.0650517, 0.0, 0.0, 1.0, 0.0, decouple
 	sound_vent_large = decouple
-	
-	
+
+
 	// --- editor parameters ---
 	TechRequired = advMetalworks
 	entryCost = 7600
 	cost = 740
 	category = Coupling
 	subcategory = 0
-	title = Mk2 Stack Separator
-	manufacturer = O.M.B. Demolition Enterprises
-	description = Unlike Decouplers, Separators jettison everything attached to them. This new technology was very well received by rocket engineers everywhere. Not bad for something that started out as a failure for a controlled explosive bolt prototype.
+	title = #LOC.mk2ess_mk2Separator_title
+	manufacturer = #LOC.mk2ess_mk2Separator_manufacturer
+	description = #LOC.mk2ess_mk2Separator_description
 	bulkheadProfiles = mk2
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
-	
+
 	// --- standard part parameters ---
 	mass = 0.095
 	dragModelType = default
@@ -46,13 +42,18 @@ PART
 	breakingTorque = 200
 	maxTemp = 2000 // 3400
 	fuelCrossFeed = False
-	
+
 	stageOffset = 1
 	childStageOffset = 1
-	
-	tags = m2x mk2 break decouple separat split stag
+
+	tags = #LOC.mk2ess_mk2Separator_tags
 
 	// ----- DO NOT EDIT BELOW THIS POINT ------
+
+	MODEL
+	{
+		model = SpaceTuxIndustries/RecycledParts/Mk2Essentials/mk2Separator/model
+	}
 	MODULE
 	{
 		name = ModuleDecouple
@@ -65,6 +66,7 @@ PART
 		useStaging = True
 		useEvent = False
 		situationMask = 127
+
 		CONSTRAINT
 		{
 			type = REPEATABILITY

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Localization/de-de.cfg
@@ -1,0 +1,18 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** Part: mk2SolarBattery1k
+
+		#LOC.soba_mk2SolarBattery1k_description = Die Mk2 Solarbatterie 1000 ist ein stapelbarer Akku mit 1000 Einheiten Stromkapazität und montierten Solarpanelen.
+		#LOC.soba_mk2SolarBattery1k_manufacturer = Zaltonic Electronics
+		#LOC.soba_mk2SolarBattery1k_title = Mk2 Solarbatterie 1000
+
+		// ********** Part: mk2SolarBattery2k
+
+		#LOC.soba_mk2SolarBattery2k_description = Die Mk2 Solarbatterie 2000 ist eine stapelbarer Akku mit 2000 Einheiten Stromkapazität und montierten Solarpanelen.
+		#LOC.soba_mk2SolarBattery2k_manufacturer = Zaltonic Electronics
+		#LOC.soba_mk2SolarBattery2k_title = Mk2 Solarbatterie 2000
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Localization/en-us.cfg
@@ -1,0 +1,18 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** Part: mk2SolarBattery1k
+
+		#LOC.soba_mk2SolarBattery1k_description = Mk2 Solar Battery 1k  is a stackable battery bank, with a built-in solar panel
+		#LOC.soba_mk2SolarBattery1k_manufacturer = Zaltonic Electronics
+		#LOC.soba_mk2SolarBattery1k_title = Mk2 Solar Battery 1000
+
+		// ********** Part: mk2SolarBattery2k
+
+		#LOC.soba_mk2SolarBattery2k_description = Mk2 Solar Battery 2k
+		#LOC.soba_mk2SolarBattery2k_manufacturer = Zaltonic Electronics
+		#LOC.soba_mk2SolarBattery2k_title = Mk2 Solar Battery 2000
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Parts/SolarBattery1k/mk2SolarBattery1k.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Parts/SolarBattery1k/mk2SolarBattery1k.cfg
@@ -12,9 +12,9 @@ PART
 	cost = 1000
 	category = Electrical
 	subcategory = 0
-	title = Mk2 Solar Battery 1k
-	manufacturer = Zaltonic Electronics
-	description = Mk2 Solar Battery 1k  is a stackable battery bank, with a built-in solar panel
+	title = #LOC.soba_mk2SolarBattery1k_title
+	manufacturer = #LOC.soba_mk2SolarBattery1k_manufacturer
+	description = #LOC.soba_mk2SolarBattery1k_description
 	bulkheadProfiles = mk2
 	attachRules = 1,0,1,1,0
 	mass = 0.06
@@ -28,7 +28,7 @@ PART
 	maxTemp = 2000
 
 	bulkheadProfiles = mk2
-	tags = #autoLOC_500393 //#autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
+	tags = #autoLOC_500393 // #autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
 
 	MODULE
 	{
@@ -50,13 +50,10 @@ PART
 		resourceName = ElectricCharge
 		chargeRate = 1.4
 	}
-	
-	
 	RESOURCE
 	{
-	 name = ElectricCharge
-	 amount = 1000
-	 maxAmount = 1000
+		name = ElectricCharge
+		amount = 1000
+		maxAmount = 1000
 	}
-	
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Parts/SolarBattery2k/mk2SolarBattery2k.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/Mk2SolarBatteries/Parts/SolarBattery2k/mk2SolarBattery2k.cfg
@@ -12,9 +12,9 @@ PART
 	cost = 1800
 	category = Electrical
 	subcategory = 0
-	title = Mk2 Solar Battery 2k
-	manufacturer = Zaltonic Electronics
-	description = Mk2 Solar Battery 2k
+	title = #LOC.soba_mk2SolarBattery2k_title
+	manufacturer = #LOC.soba_mk2SolarBattery2k_manufacturer
+	description = #LOC.soba_mk2SolarBattery2k_description
 	bulkheadProfiles = mk2
 	attachRules = 1,0,1,1,0
 	mass = 0.12
@@ -28,7 +28,7 @@ PART
 	maxTemp = 2000
 
 	bulkheadProfiles = mk2
-	tags = #autoLOC_500393 //#autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
+	tags = #autoLOC_500393 // #autoLOC_500393 = capacitor cell charge e/c elect pack power volt watt
 
 	MODULE
 	{
@@ -50,7 +50,6 @@ PART
 		resourceName = ElectricCharge
 		chargeRate = 2.8
 	}
-
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Localization/de-de.cfg
@@ -1,0 +1,20 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** Part: NAU.ORI350Gm
+
+		#LOC_NAU_ORI350Gm_description = Eine riesige blütenförmige Kommunikationsschüssel aus der "Origami Foldable Assets" Serie. Man erreicht das Meiste innerhalb des Kerbol-Systems mit der Annehmlichkeit eines faltbaren Origami.
+		#LOC_NAU_ORI350Gm_manufacturer = NAU Aerospace
+		#LOC_NAU_ORI350Gm_tags = antenne entfalten relais aufklappen falten radio signal transmi kommunikation
+		#LOC_NAU_ORI350Gm_title = NAU Ori 350Gm
+
+		// ********** Part: NAU.ORI69Gm
+
+		#LOC_NAU_ORI69Gm_description = Eine mittelgroße Radialschüssel aus der "Origami Foldable Assets" Serie. Erreicht quasi alle felsigen inneren Planeten.
+		#LOC_NAU_ORI69Gm_manufacturer = NAU Aerospace
+		#LOC_NAU_ORI69Gm_tags = antenne entfalten relais aufklappen falten radio signal transmi kommunikation
+		#LOC_NAU_ORI69Gm_title = NAU Ori 69Gm
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Localization/en-us.cfg
@@ -1,0 +1,20 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** Part: NAU.ORI350Gm
+
+		#LOC_NAU_ORI350Gm_description = A massive radial boom dish from the Origami Foldable Assets series. You'll reach most of Kerbol, with the convenience of a folding origami.
+		#LOC_NAU_ORI350Gm_manufacturer = NAU Aerospace
+		#LOC_NAU_ORI350Gm_tags = aerial antenna deploy relay extend fold radio signal transmi
+		#LOC_NAU_ORI350Gm_title = NAU Ori 350Gm
+
+		// ********** Part: NAU.ORI69Gm
+
+		#LOC_NAU_ORI69Gm_description = A medium radial dish from the Origami Foldable Assets series. Reaching all the rocky inner planets.
+		#LOC_NAU_ORI69Gm_manufacturer = NAU Aerospace
+		#LOC_NAU_ORI69Gm_tags = aerial antenna deploy relay extend fold radio signal transmi
+		#LOC_NAU_ORI69Gm_title = NAU Ori 69Gm
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Parts/ORIGAMI/ORI350Gm/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Parts/ORIGAMI/ORI350Gm/part.cfg
@@ -3,25 +3,25 @@ PART
 	name = NAU_ORI350Gm
 	module = Part
 	author = IGNOBIL
-	
+
 	mesh = ORI350.mu
 	scale = 0.1
-	
-	//node_stack_bottom = 0, 0, 0, 0.0, 1.0, 0.0
+
+	// node_stack_bottom = 0, 0, 0, 0.0, 1.0, 0.0
 	node_attach = 0, 0, 0, 0.0, -1.0, 0.0, 1
-	
+
 	TechRequired = automation
 
-	entryCost = 38500
-	cost = 11000
+	entryCost = 45500
+	cost = 15000
 	category = Communication
 	subcategory = 0
-	title = NAU ORI350GM 
-	manufacturer = NAU Aerospace
-	description = A massive radial boom dish from the Origami Foldable Assets series. You'll reach most of Kerbol, with the convenience of a folding origami.
+	title = #LOC_NAU_ORI350Gm_title
+	manufacturer = #LOC_NAU_ORI350Gm_manufacturer
+	description = #LOC_NAU_ORI350Gm_description
 	
 	attachRules = 0,1,0,0,0
-	
+
 	mass = 0.5
 	dragModelType = default
 	maximum_drag = 0.2
@@ -31,11 +31,11 @@ PART
 	maxTemp = 2000 // = 3200
 	vesselType = Relay
 	bulkheadProfiles = srf
-	
+
 	PhysicsSignificance = 1
 
-	tags = aerial antenna deploy relay extend fold radio signal transmi
-	
+	tags = #LOC_NAU_ORI350Gm_tags
+
 	MODULE
 	{
 		name = ModuleDeployableAntenna
@@ -44,22 +44,20 @@ PART
 		pivotName = Receiver
 		windResistance = 1
 		animationName = Deploy
-		extendActionName = #autoLOC_6002398 //#autoLOC_6002398 = Extend <<1>>
-		retractActionName = #autoLOC_6002399 //#autoLOC_6002399 = Retract <<1>>
-		extendpanelsActionName = #autoLOC_6002400 //#autoLOC_6002400 = Toggle <<1>>
+		extendActionName = #autoLOC_6002398 // #autoLOC_6002398 = Extend <<1>>
+		retractActionName = #autoLOC_6002399 // #autoLOC_6002399 = Retract <<1>>
+		extendpanelsActionName = #autoLOC_6002400 // #autoLOC_6002400 = Toggle <<1>>
 	}
-	
-	
 	MODULE
 	{
 		name = ModuleDataTransmitter
 		antennaType = RELAY
 		packetInterval = 0.35
-		packetSize = 2
-		packetResourceCost = 18.0
+		packetSize = 6
+		packetResourceCost = 29.0
 		requiredResource = ElectricCharge
 		DeployFxModules = 0
-		antennaPower = 5000000
+		antennaPower = 350000000000
 		antennaCombinable = True
 	}
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Parts/ORIGAMI/ORI69Gm/part.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/NAU/Parts/ORIGAMI/ORI69Gm/part.cfg
@@ -3,24 +3,24 @@ PART
 	name = NAU_ORI69Gm
 	module = Part
 	author = IGNOBIL
-	
+
 	mesh = model.mu
 	scale = 0.1
-	
-	//node_stack_bottom = 0, 0, 0, 0.0, 1.0, 0.0
+
+	// node_stack_bottom = 0, 0, 0, 0.0, 1.0, 0.0
 	node_attach = 0, 0, 0, 0.0, -1.0, 0.0, 1
-	
+
 	TechRequired = automation
-	entryCost = 38500
-	cost = 11000
+	entryCost = 19000
+	cost = 3400
 	category = Communication
 	subcategory = 0
-	title = NAU ORI69GM 
-	manufacturer = NAU Aerospace
-	description = A medium radial dish from the Origami Foldable Assets series. Reaching all the rocky inner planets.
-	
+	title = #LOC_NAU_ORI69Gm_title
+	manufacturer = #LOC_NAU_ORI69Gm_manufacturer
+	description = #LOC_NAU_ORI69Gm_description
+
 	attachRules = 0,1,0,0,0
-	
+
 	mass = 0.2
 	dragModelType = default
 	maximum_drag = 0.2
@@ -30,10 +30,10 @@ PART
 	maxTemp = 2000 // = 3200
 	vesselType = Relay
 	bulkheadProfiles = srf
-	
+
 	PhysicsSignificance = 1
 
-	tags = aerial antenna deploy relay extend fold radio signal transmi
+	tags = #LOC_NAU_ORI69Gm_tags
 
 	MODULE
 	{
@@ -43,22 +43,20 @@ PART
 		pivotName = receiver_cap
 		windResistance = 1
 		animationName = Deploy
-		extendActionName = #autoLOC_6002398 //#autoLOC_6002398 = Extend <<1>>
-		retractActionName = #autoLOC_6002399 //#autoLOC_6002399 = Retract <<1>>
-		extendpanelsActionName = #autoLOC_6002400 //#autoLOC_6002400 = Toggle <<1>>
+		extendActionName = #autoLOC_6002398 // #autoLOC_6002398 = Extend <<1>>
+		retractActionName = #autoLOC_6002399 // #autoLOC_6002399 = Retract <<1>>
+		extendpanelsActionName = #autoLOC_6002400 // #autoLOC_6002400 = Toggle <<1>>
 	}
-	
-	
 	MODULE
 	{
-	    name = ModuleDataTransmitter
-	    antennaType = RELAY
-	    packetInterval = 0.35
-	    packetSize = 2
-	    packetResourceCost = 18.0
-	    requiredResource = ElectricCharge
-	    DeployFxModules = 0
-	    antennaPower = 5000000
-	    antennaCombinable = True
+		name = ModuleDataTransmitter
+		antennaType = RELAY
+		packetInterval = 0.35
+		packetSize = 4
+		packetResourceCost = 26.0
+		requiredResource = ElectricCharge
+		DeployFxModules = 0
+		antennaPower = 69000000000
+		antennaCombinable = True
 	}
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Localization/de-de.cfg
@@ -1,0 +1,62 @@
+Localization
+{
+	de-de
+	{
+
+	// ********** All Parts:
+		#LOC.rsc_manufacturer = R&S Capsuledyne
+
+	// ********** Part: Size3SASBatt
+
+		#LOC.rsc_Size3SASBatt_description = Größer ist immer besser, jedoch möchte R&S Capsuledyne es nicht übertreiben - so daß die Batterie nur 8000 Einheiten Strom speichert. Um das zu kompensieren haben R&S's cleverste Ingenieure die Batterie mit einem großen Reaktionsrad ummantelt - ein leistungsfähiges Paket!
+		#LOC.rsc_Size3SASBatt_tags = kondensator zelle laden strom elekt satz saft volt watt ruderausschlag gyroskop steuern fliegen gyro moment reagieren stab steuern drehmoment
+		#LOC.rsc_Size3SASBatt_title = R&S Z-8K Akku-Reaktionsrad-Modul
+
+		// ********** Part: Size3TinyTank
+
+		#LOC.rsc_Size3TinyTank_description = Für solch einen großen Treibstofftank, ist dies ein kleiner Treibstofftank. Am effektivsten für obere Stufen mit großen Durchmessern. Vertrau uns.
+		#LOC.rsc_Size3TinyTank_title = R&S Capsuledyne S3-1800 Tank
+
+		// ********** Part: stackSeparatorHuge
+
+		#LOC.rsc_stackSeparatorHuge_description = Nachdem keine nicht-eplosiven Bolzen mehr da waren, haben R&S-Ingenieure festgestellt: Warum nicht einfach beide Seiten abkoppeln?
+		#LOC.rsc_stackSeparatorHuge_tags = bruch spreng entkoppel separat teilen stufe
+		#LOC.rsc_stackSeparatorHuge_title = XLG-3 Stapel-Separator
+
+		// ********** Part: TaurusHCV
+
+		#LOC.rsc_TaurusHCV_description = Nur wenige Wochen, nachdem Pläne für eine große Raumkapsel aus Rockomax's Labor verschwunden sind, hat R&S Capsuledyne den Markt mit dieser atemberaubender Innovation gestürmt. Gerichtsverfahren ausstehend.
+		#LOC.rsc_TaurusHCV_title = Taurus HCV
+
+		// ********** Part: TaurusHeatshield
+
+		#LOC.rsc_TaurusHeatshield_description = Nach einigen Tests fanden Piloten die Tauruskapsel nicht "spacey genug", daraufhin hat das R&S-Team dieses Hitzeschild draufgepackt, um sie zum Schweigen zu bringen. Zudem schützt es die Kapsel bei Wiedereintritt in die Atmosphäre.
+		#LOC.rsc_TaurusHeatshield_title = Taurus HCV Hitzeschild
+
+		// ********** Part: TaurusHitchhiker
+
+		#LOC.rsc_TaurusHitchhiker_description = Für die ganz großen Transporter oder Raumstationen sorgt R&S mit diesem "bequemen", "spacy" und unter Druck stehenden MCT-8 Passagiertransportmodul.
+		#LOC.rsc_TaurusHitchhiker_title = MCT-8 Omnibus Aufbewahrungsbehälter
+
+		// ********** Part: taurusNuclearEngine
+
+		#LOC.rsc_taurusNuclearEngine_description = Wenn du etwas großes und schweres durch die Tiefen des Alls bewegen musst, brauchst du R&S Capsuledyne's Antriebsabteilungs-Nuklearabteilung's neuesten geborgenen Atomraketen-Motor!
+		#LOC.rsc_taurusNuclearEngine_title = RS-2 "Tiny" X-tragroßer Atomraketen-Motor
+
+		// ********** Part: TaurusOrbitalEngine
+
+		#LOC.rsc_TaurusOrbitalEngine_description = Irgendjemand hat alle gebrauchten Rockomax Poodles vom Markt aufgekauft. In unabhängigen Nachrichten hat R&S Capsuldyne ihr neues großes Orbitaltriebwerk mit bekanntem Design veröffentlicht! Ein bemerkenswerter Zufall.
+		#LOC.rsc_TaurusOrbitalEngine_tags = orbit (quadroodle antrieb rakete triebwerk
+		#LOC.rsc_TaurusOrbitalEngine_title = RKMX-4.1 "Quadroodle" Flüssigtreibstoff-Triebwerk
+
+		// ********** Part: TaurusScienceBay
+
+		#LOC.rsc_TaurusScienceBay_description = Optimiere dein Raumschiff, eine Raumstation oder Bodenforschungseinrichtungen mit R&S Capsuledyne's kombinierten mobilen Forschlungslabor und Frachtraummodul. ANWALTLICHE NOTIZ: Frachtraum nicht zum Transport von Kerbals zertifiziert.
+		#LOC.rsc_TaurusScienceBay_title = SPB-HUGE-3 Mobiles Forschlungslabor und Frachtraum
+
+		// ********** Part: XLOreTank
+
+		#LOC.rsc_XLOreTank_description = Erster Gedanke nach einem alamierenden Unfall mit einer extragroßen elastischen Burg malten R&S Capsuledyne Ingenieure ihr Logo darauf.
+		#LOC.rsc_XLOreTank_title = RSTX - Sehr großer Lagertank
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Localization/de-de.cfg
@@ -30,7 +30,7 @@ Localization
 
 		// ********** Part: TaurusHeatshield
 
-		#LOC.rsc_TaurusHeatshield_description = Nach einigen Tests fanden Piloten die Tauruskapsel nicht "spacey genug", daraufhin hat das R&S-Team dieses Hitzeschild draufgepackt, um sie zum Schweigen zu bringen. Zudem schützt es die Kapsel bei Wiedereintritt in die Atmosphäre.
+		#LOC.rsc_TaurusHeatshield_description = Nach einigen Tests fanden Piloten die Tauruskapsel nicht "spacey genug", daraufhin hat das R&S-Team diesen Hitzeschild draufgepackt, um sie zum Schweigen zu bringen. Zudem schützt es die Kapsel bei Wiedereintritt in die Atmosphäre.
 		#LOC.rsc_TaurusHeatshield_title = Taurus HCV Hitzeschild
 
 		// ********** Part: TaurusHitchhiker
@@ -51,12 +51,12 @@ Localization
 
 		// ********** Part: TaurusScienceBay
 
-		#LOC.rsc_TaurusScienceBay_description = Optimiere dein Raumschiff, eine Raumstation oder Bodenforschungseinrichtungen mit R&S Capsuledyne's kombinierten mobilen Forschlungslabor und Frachtraummodul. ANWALTLICHE NOTIZ: Frachtraum nicht zum Transport von Kerbals zertifiziert.
+		#LOC.rsc_TaurusScienceBay_description = Optimiere dein Raumschiff, eine Raumstation oder Bodenforschungseinrichtungen mit R&S Capsuledyne's kombiniertem mobilen Forschlungslabor und Frachtraummodul. ANWALTLICHE NOTIZ: Frachtraum nicht zum Transport von Kerbals zertifiziert.
 		#LOC.rsc_TaurusScienceBay_title = SPB-HUGE-3 Mobiles Forschlungslabor und Frachtraum
 
 		// ********** Part: XLOreTank
 
-		#LOC.rsc_XLOreTank_description = Erster Gedanke nach einem alamierenden Unfall mit einer extragroßen elastischen Burg malten R&S Capsuledyne Ingenieure ihr Logo darauf.
+		#LOC.rsc_XLOreTank_description = Der erste Gedanke nach einem alarmierenden Unfall mit einer extragroßen elastischen Burg: R&S Capsuledyne Ingenieure malten ihr Logo darauf.
 		#LOC.rsc_XLOreTank_title = RSTX - Sehr großer Lagertank
 	}
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Localization/en-us.cfg
@@ -1,0 +1,62 @@
+Localization
+{
+	en-us
+	{
+
+	// ********** All Parts:
+		#LOC.rsc_manufacturer = R&S Capsuledyne
+
+	// ********** Part: Size3SASBatt
+
+		#LOC.rsc_Size3SASBatt_description = Bigger is always better, and R&S Capsuledyne didn't want to over do it - so the battery only holds 8000 units of electricity. To make up for this, R&S's finest engineers surrounded the battery with a big reaction wheel - leading to a very capable package.
+		#LOC.rsc_Size3SASBatt_tags = capacitor cell charge e/c elect pack power volt watt cmg command control fly gyro moment react stab steer torque
+		#LOC.rsc_Size3SASBatt_title = R&S Z-8K Rechargeable Battery Reaction Wheel Module
+
+		// ********** Part: Size3TinyTank
+
+		#LOC.rsc_Size3TinyTank_description = For such a large fuel tank, this is a pretty small fuel tank. It works best for large diameter upper stages. Trust us.
+		#LOC.rsc_Size3TinyTank_title = R&S Capsuledyne S3-1800 Tank
+
+		// ********** Part: stackSeparatorHuge
+
+		#LOC.rsc_stackSeparatorHuge_description = After running out of non-explosive bolts, the R&S Capsuledyne engineers realized something: why not make it detach from *both* sides?
+		#LOC.rsc_stackSeparatorHuge_tags = break decouple separat split stag
+		#LOC.rsc_stackSeparatorHuge_title = XLG-3 Stack Separator
+
+		// ********** Part: TaurusHCV
+
+		#LOC.rsc_TaurusHCV_description = Just weeks after plans for a very large capsule disappeared from Rockomax labs, R&S Capsuledyne burst into the market with this staggering and original innovation. Lawsuit pending.
+		#LOC.rsc_TaurusHCV_title = Taurus HCV
+
+		// ********** Part: TaurusHeatshield
+
+		#LOC.rsc_TaurusHeatshield_description = After test pilots complained that the Taurus didn't look "spacey enough", the R&S team whipped up this "heatshield" to make them shut up. It also keeps the capsule safe during reentry, or whatever.
+		#LOC.rsc_TaurusHeatshield_title = Taurus HCV Heat Shield
+
+		// ********** Part: TaurusHitchhiker
+
+		#LOC.rsc_TaurusHitchhiker_description = For the largest of transports and space stations, R&S has you covered with the "comfortable", "spacious", and "pressurized" MCT-8 crew transport module.
+		#LOC.rsc_TaurusHitchhiker_title = MCT-8 Omnibus Storage Container
+
+		// ********** Part: taurusNuclearEngine
+
+		#LOC.rsc_taurusNuclearEngine_description = If you need to move something big and heavy through deep space, you need R&S Capsuledyne Propulsion Division Atomic Division's new salvaged atomic rocket engine!
+		#LOC.rsc_taurusNuclearEngine_title = RS-2 "Tiny" X-tra Large Atomic Motor
+
+		// ********** Part: TaurusOrbitalEngine
+
+		#LOC.rsc_TaurusOrbitalEngine_description = Someone's been buying all the used Rockomax Poodles off the market. In unrelated news, R&S Capsuldyne has unveiled their new large orbital engine with a familiar design! It's really a staggering coincidence.
+		#LOC.rsc_TaurusOrbitalEngine_tags = orbit (quadroodle propuls rocket
+		#LOC.rsc_TaurusOrbitalEngine_title = RKMX-4.1 "Quadroodle" Liquid Fuel Engine
+
+		// ********** Part: TaurusScienceBay
+
+		#LOC.rsc_TaurusScienceBay_description = Streamline your launch vehicle, space station, or basement laboratory with the R&S Capsuledyne combined science processing module and cargo storage bay. LAWYER'S NOTE: Cargo bay not certified for Kerbal transport.
+		#LOC.rsc_TaurusScienceBay_title = SPB-HUGE-3 Science Processing / Cargo Bay
+
+		// ********** Part: XLOreTank
+
+		#LOC.rsc_XLOreTank_description = First thought up after an alarming accident involving an extra large bouncy castle, R&S Capsuledyne engineers painted on their logo and called it a day.
+		#LOC.rsc_XLOreTank_title = RSTX - Very Large Holding Tank
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/Engine/TaurusOrbitalEngine.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/Engine/TaurusOrbitalEngine.cfg
@@ -1,11 +1,10 @@
 PART
 {
 	module = Part
-	name = TaurusOrbitalEngine //***************
-	mesh = QuadroodleMDL.mu //***************
-	title = RKMX-4.1 "Quadroodle" Liquid Fuel Engine //***************
-	author = J. Robinson, J. Sathe, Skalou //***************
-	tags = orbit (quadroodle propuls rocket
+	name = TaurusOrbitalEngine // ***************
+	mesh = QuadroodleMDL.mu // ***************
+	author = J. Robinson, J. Sathe, Skalou // ***************
+	tags = #LOC.rsc_TaurusOrbitalEngine_tags
 	bulkheadProfiles = size3
 	heatConductivity = 0.06
 	emissiveConstant = 0.8
@@ -20,8 +19,9 @@ PART
 	dragModelType = default
 	mass = 6
 	attachRules = 1,0,1,0,0
-	description = Someone's been buying all the used Rockomax Poodles off the market. In unrelated news, R&S Capsuldyne has unveiled their new large orbital engine with a familiar design! It's really a staggering coincidence.
-	manufacturer = R&S Capsuledyne
+	title = #LOC.rsc_TaurusOrbitalEngine_title
+	description = #LOC.rsc_TaurusOrbitalEngine_description
+	manufacturer = #LOC.rsc_manufacturer
 	subcategory = 0
 	category = Engine
 	cost = 6499
@@ -37,6 +37,7 @@ PART
 	node_stack_bottom = 0.0, -0.80, 0.0, 0.0, -1.0, 0.0, 3
 	node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 3
 	rescaleFactor = 1
+
 	MODULE
 	{
 		EngineType = LiquidFuel
@@ -48,6 +49,7 @@ PART
 		exhaustDamage = True
 		thrustVectorTransformName = thrustTransform
 		name = ModuleEngines
+
 		PROPELLANT
 		{
 			DrawGauge = True
@@ -90,10 +92,10 @@ PART
 		dependOnEngineState = True
 		responseSpeed = 0.001
 	}
-
 	MODULE
 	{
 		name = ModuleAlternator
+
 		RESOURCE
 		{
 			rate = 8.0
@@ -111,7 +113,7 @@ PART
 	MODULE
 	{
 		name = ModuleSurfaceFX
-		thrustTransformName = SurfaceFX //***************
+		thrustTransformName = SurfaceFX // ***************
 		falloff = 1.5
 		maxDistance = 75
 		fxMax = 0.75

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/FuelTank/Size3TinyTank.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/FuelTank/Size3TinyTank.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = fuel fueltank ?lfo propellant rocket
+	tags = #autoLOC_500528 //#autoLOC_500528 = fueltank ?lfo liquid oxidizer propellant rocket
 	bulkheadProfiles = size3, srf
 	node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 	maxTemp = 2000
@@ -13,9 +13,9 @@ PART
 	dragModelType = default
 	mass = 1.125
 	attachRules = 1,1,1,1,0
-	description = For such a large fuel tank, this is a pretty small fuel tank. It works best for large diameter upper stages. Trust us.
-	manufacturer = R&S Capsuledyne
-	title = R&S Capsuledyne S3-1800 Tank
+	description = #LOC.rsc_Size3TinyTank_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_Size3TinyTank_title
 	subcategory = 0
 	category = FuelTank
 	cost = 1625

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/Heatshield/TaurusHeatshield.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/Heatshield/TaurusHeatshield.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = ablat drag entry insulate protect re- rocket therm
+	tags = #autoLOC_500189 //#autoLOC_500189 = ablat drag entry insulate protect re- rocket therm
 	bulkheadProfiles = size3
 	PhysicsSignificance = 0
 	childStageOffset = 1
@@ -19,9 +19,9 @@ PART
 	dragModelType = default
 	mass = 1.0
 	attachRules = 1,0,1,0,0
-	description = After test pilots complained that the Taurus didn't look "spacey enough", the R&S team whipped up this "heatshield" to make them shut up. It also keeps the capsule safe during reentry, or whatever.
-	manufacturer = R&S Capsuledyne
-	title = Taurus HCV Heat Shield
+	description = #LOC.rsc_TaurusHeatshield_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_TaurusHeatshield_title
 	entryCost = 1800
 	TechRequired = advLanding
 	subcategory = 0
@@ -37,6 +37,7 @@ PART
 	author = J. Robinson, J. Sathe
 	module = Part
 	name = TaurusHeatshield
+
 	MODULE
 	{
 		checkBottomNode = True
@@ -85,6 +86,7 @@ PART
 		shaderProperty = _BurnColor
 		moduleID = shieldChar
 		name = ModuleColorChanger
+
 		redCurve
 		{
 			key = 1 1

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/Nuke/taurusNuclearEngine.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/Nuke/taurusNuclearEngine.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = active atom efficient engine inter liquid (tiny nuclear nuke orbit propuls radio reactor vacuum
+	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum
 	bulkheadProfiles = size3
 	radiatorMax = 0.35 //Default = 0.25 but nuke engines are meant to run hot
 	heatConductivity = 0.06	// half default
@@ -16,9 +16,9 @@ PART
 	dragModelType = default
 	mass = 15
 	attachRules = 1,0,1,0,0
-	description = If you need to move something big and heavy through deep space, you need R&S Capsuledyne Propulsion Division Atomic Division's new salvaged atomic rocket engine!
-	manufacturer = R&S Capsuledyne
-	title = RS-2 "Tiny" X-tra Large Atomic Motor
+	description = #LOC.rsc_taurusNuclearEngine_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_taurusNuclearEngine_title
 	subcategory = 0
 	category = Engine
 	cost = 30900

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/OreTank/XLOreTank.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/OreTank/XLOreTank.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = black isru mine )mining (ore resource store
+	tags = #autoLOC_500672 //#autoLOC_500672 = black isru mine )mining (ore resource store
 	bulkheadProfiles = size3, srf
 	maxTemp = 2000
 	crashTolerance = 7
@@ -10,9 +10,9 @@ PART
 	dragModelType = default
 	mass = 4.667
 	attachRules = 1,1,1,1,0
-	description = First thought up after an alarming accident involving an extra large bouncy castle, R&S Capsuledyne engineers painted on their logo and called it a day.
-	manufacturer = R&S Capsuledyne
-	title = Very Large Holding Tank
+	description = #LOC.rsc_XLOreTank_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_XLOreTank_title
 	subcategory = 0
 	category = FuelTank
 	cost = 6500

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/SASBatt/Size3SASBatt.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/SASBatt/Size3SASBatt.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = capacitor cell charge e/c elect pack power volt watt cmg command control fly gyro moment react stab steer torque
+	tags = #LOC.rsc_Size3SASBatt_tags // #LOC.rsc_Size3SASBatt_tags = capacitor cell charge e/c elect pack power volt watt cmg command control fly gyro moment react stab steer torque
 	bulkheadProfiles = size3
 	breakingTorque = 200
 	breakingForce = 200
@@ -12,9 +12,9 @@ PART
 	dragModelType = default
 	mass = 0.733
 	attachRules = 1,0,1,1,0
-	description = Bigger is always better, and R&S Capsuledyne didn't want to over do it - so the battery only holds 8000 units of electricity. To make up for this, R&S's finest engineers surrounded the battery with a big reaction wheel - leading to a very capable package.
-	manufacturer = R&S Capsuledyne
-	title = R&S Z-8K Rechargeable Battery Reaction Wheel Module
+	description = #LOC.rsc_Size3SASBatt_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_Size3SASBatt_title
 	subcategory = 0
 	category = Control
 	cost = 12000
@@ -27,6 +27,7 @@ PART
 	author = J. Robinson, J. Sathe
 	module = Part
 	name = Size3SASBatt
+
 	RESOURCE
 	{
 		maxAmount = 8000
@@ -40,6 +41,7 @@ PART
 		YawTorque = 50
 		PitchTorque = 50
 		name = ModuleReactionWheel
+
 		RESOURCE
 		{
 			rate = 1.0

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/ScienceBay/TaurusHitchhiker.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/ScienceBay/TaurusHitchhiker.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = base cabin (can outpost passenger statio tour tuna
+	tags = #autoLOC_500297 //#autoLOC_500297 = base cabin (can outpost passenger statio tour tuna
 	bulkheadProfiles = size3
 	noAutoEVAMulti = True
 	CrewCapacity = 8
@@ -16,9 +16,9 @@ PART
 	dragModelType = default
 	mass = 5
 	attachRules = 1,0,1,1,0
-	description = For the largest of transports and space stations, R&S has you covered with the "comfortable", "spacious", and "pressurized" MCT-8 crew transport module.
-	manufacturer = R&S Capsuledyne
-	title = MCT-8 Omnibus Storage Container
+	description = #LOC.rsc_TaurusHitchhiker_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_TaurusHitchhiker_title
 	subcategory = 0
 	category = Utility
 	cost = 8000
@@ -30,6 +30,7 @@ PART
 	author = J. Robinson, J. Sathe
 	module = Part
 	name = TaurusHitchhiker
+
 	MODEL
 	{
 		scale = 1,1,1

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/ScienceBay/TaurusScienceBay.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/ScienceBay/TaurusScienceBay.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = experiment laboratory research science
+	tags = #autoLOC_500690 //#autoLOC_500690 = experiment laboratory research science
 	bulkheadProfiles = size3
 	noAutoEVAMulti = True
 	CrewCapacity = 3
@@ -16,9 +16,9 @@ PART
 	dragModelType = default
 	mass = 5.5
 	attachRules = 1,0,1,1,0
-	description = Streamline your launch vehicle, space station, or basement laboratory with the R&S Capsuledyne combined science processing module and cargo storage bay. LAWYER'S NOTE: Cargo bay not certified for Kerbal transport.
-	manufacturer = R&S Capsuledyne
-	title = SPB-HUGE-3 Science Processing / Cargo Bay
+	description = #LOC.rsc_TaurusScienceBay_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_TaurusScienceBay_title
 	subcategory = 0
 	category = Science
 	cost = 6000
@@ -30,6 +30,7 @@ PART
 	author = J. Robinson, J. Sathe
 	module = Part
 	name = TaurusScienceBay
+
 	MODEL
 	{
 		scale = 1,1,1
@@ -57,6 +58,7 @@ PART
 		dataStorage = 1250
 		containerModuleIndex = 0
 		name = ModuleScienceLab
+
 		RESOURCE_PROCESS
 		{
 			amount = 12.5
@@ -66,15 +68,15 @@ PART
 	MODULE
 	{
 		ToggleActionName = Toggle Research
-		dataProcessingMultiplier = 0.5	// Multiplier to data processing rate and therefore science rate
+		dataProcessingMultiplier = 0.5 // Multiplier to data processing rate and therefore science rate
 		StopActionName = Stop Research
 		StartActionName = Start Research
 		ConverterName = Research
-		powerRequirement = 6	//EC/Sec to research
-		scienceCap = 1250	//How much science can we store before having to transmit?	
-		scienceMultiplier = 5.5	//How much science does data turn into?
-		researchTime = 7	//Larger = slower.	Exponential!
-		scientistBonus = 0.25	//Bonus per scientist star - need at least one! So 0.25x - 2.5x 
+		powerRequirement = 6 // EC/Sec to research
+		scienceCap = 1250 // How much science can we store before having to transmit?
+		scienceMultiplier = 5.5 // How much science does data turn into?
+		researchTime = 7 // Larger = slower.	Exponential!
+		scientistBonus = 0.25 // Bonus per scientist star - need at least one! So 0.25x - 2.5x
 		name = ModuleScienceConverter
 	}
 	MODULE
@@ -123,6 +125,7 @@ PART
 		MaximumFoV = 63
 		MinimumFoV = 17
 		name = ModuleKerbNetAccess
+
 		DISPLAY_MODES
 		{
 			Mode = Biome

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/StackSeparator/stackSeparatorHuge.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/StackSeparator/stackSeparatorHuge.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = break decouple separat split stag
+	tags = #LOC.rsc_stackSeparatorHuge_tags // #LOC.rsc_stackSeparatorHuge_tags = break decouple separat split stag
 	bulkheadProfiles = size3
 	childStageOffset = 1
 	stageOffset = 1
@@ -16,9 +16,9 @@ PART
 	dragModelType = default
 	mass = 0.85
 	attachRules = 1,0,1,1,0
-	description = After running out of non-explosive bolts, the R&S Capsuledyne engineers realized something: why not make it detach from *both* sides?
-	manufacturer = R&S Capsuledyne
-	title = XLG-3 Stack Separator
+	description = #LOC.rsc_stackSeparatorHuge_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_stackSeparatorHuge_title
 	subcategory = 0
 	category = Coupling
 	cost = 1450
@@ -34,6 +34,7 @@ PART
 	author = J. Robinson, J. Sathe
 	module = Part
 	name = stackSeparatorHuge
+
 	MODULE
 	{
 		ejectionForce = 1200

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/TaurusHCV/TaurusHCV.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/RSCapsuledyne/Parts/TaurusHCV/TaurusHCV.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	tags = capsule cmg control ?eva fly gyro ?iva moment pilot react rocket space stab steer torque
+	tags = #autoLOC_501807 // #autoLOC_501807 = capsule cmg control ?eva fly gyro ?iva moment pilot react rocket space stab steer torque
 	bulkheadProfiles = size1, size3
 	bodyLiftOnlyAttachName = bottom
 	bodyLiftOnlyUnattachedLift = True
@@ -23,9 +23,9 @@ PART
 	dragModelType = default
 	mass = 7.5
 	attachRules = 1,0,1,1,0
-	description = Just weeks after plans for a very large capsule disappeared from Rockomax labs, R&S Capsuledyne burst into the market with this staggering and original innovation. Lawsuit pending.
-	manufacturer = R&S Capsuledyne
-	title = Taurus HCV
+	description = #LOC.rsc_TaurusHCV_description
+	manufacturer = #LOC.rsc_manufacturer
+	title = #LOC.rsc_TaurusHCV_title
 	subcategory = 0
 	category = Pods
 	cost = 7000
@@ -39,6 +39,7 @@ PART
 	author = J. Robinson, J. Sathe
 	module = Part
 	name = TaurusHCV
+
 	MODULE
 	{
 		EngineType = SolidBooster
@@ -52,6 +53,7 @@ PART
 		throttleLocked = True
 		thrustVectorTransformName = thrustTransform
 		name = ModuleEngines
+
 		PROPELLANT
 		{
 			DrawGauge = True
@@ -101,6 +103,7 @@ PART
 		YawTorque = 20
 		PitchTorque = 20
 		name = ModuleReactionWheel
+
 		RESOURCE
 		{
 			rate = 0.96
@@ -125,8 +128,8 @@ PART
 	MODULE
 	{
 		name = ModuleScienceContainer
-		reviewActionName = #autoLOC_502201 //#autoLOC_502201 = Review Stored Data
-		storeActionName = #autoLOC_502202 //#autoLOC_502202 = Store Experiments
+		reviewActionName = #autoLOC_502201 // #autoLOC_502201 = Review Stored Data
+		storeActionName = #autoLOC_502202 // #autoLOC_502202 = Store Experiments
 		evaOnlyStorage = True
 		storageRange = 2.0
 	}
@@ -187,10 +190,11 @@ PART
 		toggleInFlight = true
 		unfocusedRange = 5
 		toggleName = Toggle Lights
-		eventOnName = #autoLOC_6001409 	//#autoLOC_6001409 = Lights On
-		eventOffName = #autoLOC_6001408 	//#autoLOC_6001408 = Lights Off
+		eventOnName = #autoLOC_6001409 // #autoLOC_6001409 = Lights On
+		eventOffName = #autoLOC_6001408 // #autoLOC_6001408 = Lights Off
 		toggleAction = True
 		defaultActionGroup = Light
+
 		redCurve
 		{
 			key = 0 0 0 3

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/Localization/de-de.cfg
@@ -1,0 +1,35 @@
+Localization
+{
+	de-de
+	{
+
+	// ********** All Parts:
+
+		#LOC.ftnm_manufacturer = Nucleonics Ltd.
+		
+	// ********** Part: 2mToroidFuOx
+
+		#LOC.ftnm_2mToroidFuOx_description = Praktisch geformter Treibstofftank für Sonden und Landemodule.
+		#LOC.ftnm_2mToroidFuOx_title = 2.5m Ringtreibstofftank
+
+		// ********** Part: ftmn160
+
+		#LOC.ftnm_ftmn160_description = Die neueste und größte Errungenschaft unter den Atomartriebwerken nutzt die verbesserte strukturelle Charakteristik des "Zylinders".
+		#LOC.ftnm_ftmn160_title = FTmN 160 Nukleartriebwerk
+
+		// ********** Part: ftmn280
+
+		#LOC.ftnm_ftmn280_description = Sollte es zum unerwarteten Ende der Weltraumagenturen kommen, muss das FtMN 280 Triebwerk nicht verschrottet werden. Es kann weiterhin zur Energieversorgung kleiner Länder oder extrem großer U-Boote genutzt werden.
+		#LOC.ftnm_ftmn280_title = FTmN 280 Nukleartriebwerk
+
+		// ********** Part: ftmn40
+
+		#LOC.ftnm_ftmn40_description = Der niedlichste Antrieb der FTmN-Baureihe.
+		#LOC.ftnm_ftmn40_title = FTmN 40 Nukleartriebwerk
+
+		// ********** Part: ltby5000
+
+		#LOC.ftnm_ltby5000_description = Einfach gesagt: Ein kleines Nukleartriebwerk.
+		#LOC.ftnm_ltby5000_title = LtBY 18K Nukleartriebwerk
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/Localization/en-us.cfg
@@ -1,0 +1,35 @@
+Localization
+{
+	en-us
+	{
+
+	// ********** All Parts:
+
+		#LOC.ftnm_manufacturer = Nucleonics Ltd.
+		
+	// ********** Part: 2mToroidFuOx
+
+		#LOC.ftnm_2mToroidFuOx_description = Conveniently shaped fuel tank for probes and landers.
+		#LOC.ftnm_2mToroidFuOx_title = 2.5m Toroidal Tank
+
+		// ********** Part: ftmn160
+
+		#LOC.ftnm_ftmn160_description = The latest and greatest in atomic engines utilises the advanced structural characteristics of the 'cylinder'.
+		#LOC.ftnm_ftmn160_title = FTmN 160 Nuclear Rocket
+
+		// ********** Part: ftmn280
+
+		#LOC.ftnm_ftmn280_description = In the event of unexpected space agency shutdown the FtMN 280 doesn't have to go to waste, use it to power small countries or excessively large submarines.
+		#LOC.ftnm_ftmn280_title = FTmN 280 Nuclear Rocket
+
+		// ********** Part: ftmn40
+
+		#LOC.ftnm_ftmn40_description = The mitey-est engine in the FTmN series.
+		#LOC.ftnm_ftmn40_title = FTmN 40 Nuclear Rocket
+
+		// ********** Part: ltby5000
+
+		#LOC.ftnm_ltby5000_description = A tiny nuclear engine.
+		#LOC.ftnm_ltby5000_title = LtBY 18K Nuclear Rocket
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ftmn160/ftmn160.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ftmn160/ftmn160.cfg
@@ -83,13 +83,13 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 28000
-	cost = 9999
+	entryCost = 40000
+	cost = 11500
 	category = Propulsion
 	subcategory = 0
-	title = FTmN 160 Nuclear Rocket
-	manufacturer = Nucleonics Ltd.
-	description = The latest and greatest in atomic engines utilises the advanced structural characteristics of the 'cylinder'.
+	title = #LOC.ftnm_ftmn160_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ftmn160_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,0,0
@@ -99,7 +99,7 @@ PART
 	heatConductivity = 0.06 // half default
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8 // engine nozzles are good at radiating.
-	mass = 5.2
+	mass = 3.1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -107,7 +107,7 @@ PART
 	crashTolerance = 6
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2000
+	maxTemp = 2800
 	bulkheadProfiles = size2
 
 	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ftmn280/ftmn280.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ftmn280/ftmn280.cfg
@@ -82,13 +82,13 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 36000
-	cost = 12000
+	entryCost = 60000
+	cost = 17500
 	category = Propulsion
 	subcategory = 0
-	title = FTmN 280 Nuclear Rocket
-	manufacturer = Nucleonics Ltd.
-	description = In the event of unexpected space agency shutdown the FtMN 280 doesn't have to go to waste, use it to power small countries or excessively large submarines.
+	title = #LOC.ftnm_ftmn280_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ftmn280_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,0,0
@@ -98,15 +98,15 @@ PART
 	heatConductivity = 0.06 // half default
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8 // engine nozzles are good at radiating.
-	mass = 7.6
+	mass = 5.6
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 2
-	crashTolerance = 5
+	crashTolerance = 6
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2000
+	maxTemp = 2800
 	bulkheadProfiles = size2
 	
 	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum
@@ -121,7 +121,7 @@ PART
 		ignitionThreshold = 0.1
 		minThrust = 0
 		maxThrust = 280
-		heatProduction = 850
+		heatProduction = 1300
 		EngineType = Nuclear
 		PROPELLANT
 		{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ftmn40/ftmn40.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ftmn40/ftmn40.cfg
@@ -83,14 +83,14 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 19000
-	cost = 7600
+	entryCost = 22000
+	cost = 5500
 	
 	category = Propulsion
 	subcategory = 0
-	title = FTmN 40 Nuclear Rocket
-	manufacturer = Nucleonics Ltd.
-	description = The mitey-est engine in the FTmN series.
+	title = #LOC.ftnm_ftmn40_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ftmn40_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,0,0
@@ -105,10 +105,10 @@ PART
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 2
-	crashTolerance = 5
+	crashTolerance = 6
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2000
+	maxTemp = 2800
 	bulkheadProfiles = size1
 
 	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ltby/ltby.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/engines/ltby/ltby.cfg
@@ -82,13 +82,13 @@ PART
 	
 	// -------- Editor ---------
 	TechRequired = nuclearPropulsion
-	entryCost = 11000
-	cost = 3500
+	entryCost = 14000
+	cost = 3800
 	category = Propulsion
 	subcategory = 0
-	title = LtBY 18K
-	manufacturer = Nucleonics Ltd.
-	description = A tiny nuclear engine.
+	title = #LOC.ftnm_ltby5000_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ltby5000_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0
@@ -103,10 +103,10 @@ PART
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 2
-	crashTolerance = 5
+	crashTolerance = 6
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2000
+	maxTemp = 2800
 	bulkheadProfiles = size0
 
 	tags = #autoLOC_500438 //#autoLOC_500438 = active atom efficient engine inter liquid (nerv nuclear nuke orbit propuls radio reactor vacuum
@@ -121,7 +121,7 @@ PART
 		ignitionThreshold = 0.1
 		minThrust = 0
 		maxThrust = 18
-		heatProduction = 80
+		heatProduction = 110
 		EngineType = Nuclear
 		PROPELLANT
 		{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/fuel tanks/toroid/2m_toroid.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn/parts/fuel tanks/toroid/2m_toroid.cfg
@@ -22,11 +22,12 @@ PART
 	cost = 850
 	category = FuelTank
 	subcategory = 0
-	title = 2.5m Toroidal Tank
-	manufacturer = Nucleonics Ltd. 
-	description = Conveniently shaped fuel tank for probes and landers.
+	title = #LOC.ftnm_2mToroidFuOx_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_2mToroidFuOx_description
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
+	
 	
 	// --- standard part parameters ---
 	mass = 0.25
@@ -39,6 +40,7 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 	bulkheadProfiles = size1
+	tags = #autoLOC_500534
 	
 	RESOURCE
 	{

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/Localization/de-de.cfg
@@ -14,7 +14,7 @@ Localization
 
 		// ********** Part: ftmn180
 
-		#LOC.ftnm_ftmn180_description = Das FTmN 180 ist die Krönung herkömmlicher Reaktormodelle. Es wurde nach Baukastenprinzip entworfen. Nucleotronics Ltd. arbeitet schwer daran, Schubsteigerungen und erhöhte Energiegeneration für den zukünftigen Bedarf neuer Nuklearantriebssysteme zu schaffen.
+		#LOC.ftnm_ftmn180_description = Das FTmN 180 ist die Krönung herkömmlicher Reaktormodelle. Es wurde nach Baukastenprinzip entworfen. Nucleotronics Ltd. arbeitet schwer daran, Schubsteigerungen und erhöhte Energiegeneration für den zukünftigen Bedarf neuer Nuklearantriebssysteme zu entwickeln.
 		#LOC.ftnm_ftmn180_title = FTmN 180 Nukleartriebwerk
 
 		// ********** Part: ftmn400
@@ -24,7 +24,7 @@ Localization
 
 		// ********** Part: ftmn80
 
-		#LOC.ftnm_ftmn80_description = Das Fission Thermal Nuclear Rocket (FTmN) 80 galt als Faust einer langen Reihe von Nuklearantrieben. Bemerkenswertes Merkmal ist der fehlende Strahlenschutz und das Kerndesign eines flüssigtreibstoffbetriebenen Nuklearantriebes, der großartigen Schub bei bescheidenem ISP bietet.
+		#LOC.ftnm_ftmn80_description = Das Fission Thermal Nuclear Rocket (FTmN) 80 galt als Rückgrat einer langen Reihe von Nuklearantrieben. Bemerkenswertes Merkmal ist der fehlende Strahlenschutz und das Kerndesign eines flüssigtreibstoffbetriebenen Nuklearantriebes, der großartigen Schub bei bescheidenem ISP bietet.
 		#LOC.ftnm_ftmn80_title = FTmN 80 Nukleartriebwerk
 	}
 }

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/Localization/de-de.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/Localization/de-de.cfg
@@ -1,0 +1,30 @@
+Localization
+{
+	de-de
+	{
+
+		// ********** All Parts:
+
+		#LOC.ftnm_manufacturer = Nucleonics Ltd.
+		
+		// ********** Part: bl40n
+
+		#LOC.ftnm_bl40n_description = Verbessertes, kompaktes Kugelform-Reaktordesign. Das BL-40-N wurde für unterschiedlichste Missionen entwickelt. Genutzt, einzeln oder in Triebwerksgruppen.
+		#LOC.ftnm_bl40n_title = BL-40-N Nukleartriebwerk
+
+		// ********** Part: ftmn180
+
+		#LOC.ftnm_ftmn180_description = Das FTmN 180 ist die Krönung herkömmlicher Reaktormodelle. Es wurde nach Baukastenprinzip entworfen. Nucleotronics Ltd. arbeitet schwer daran, Schubsteigerungen und erhöhte Energiegeneration für den zukünftigen Bedarf neuer Nuklearantriebssysteme zu schaffen.
+		#LOC.ftnm_ftmn180_title = FTmN 180 Nukleartriebwerk
+
+		// ********** Part: ftmn400
+
+		#LOC.ftnm_ftmn400_description = Ziel dieses Antriebs ist es, etwas richtig Großes an das Ende eines riesigen Raumfahrzeuges zu montieren. Es beherbergt einen Reaktor, groß genug um eine Kleinstadt zu versorgen (im unglücklichen Fall auch, um eine Stadt unbewohnbar zu machen). Es verfügt über doppelte Turbopumpen, um beeindruckend zu wirken und beinhaltet einen Abgaskrümmer, der wahrscheinlich nur gewählt wurde, um nach einem richtig großen Raketentriebwerk auszusehen.
+		#LOC.ftnm_ftmn400_title = FTmN 400 Nukleartriebwerk
+
+		// ********** Part: ftmn80
+
+		#LOC.ftnm_ftmn80_description = Das Fission Thermal Nuclear Rocket (FTmN) 80 galt als Faust einer langen Reihe von Nuklearantrieben. Bemerkenswertes Merkmal ist der fehlende Strahlenschutz und das Kerndesign eines flüssigtreibstoffbetriebenen Nuklearantriebes, der großartigen Schub bei bescheidenem ISP bietet.
+		#LOC.ftnm_ftmn80_title = FTmN 80 Nukleartriebwerk
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/Localization/en-us.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/Localization/en-us.cfg
@@ -1,0 +1,30 @@
+Localization
+{
+	en-us
+	{
+
+		// ********** All Parts:
+
+		#LOC.ftnm_manufacturer = Nucleonics Ltd.
+		
+		// ********** Part: bl40n
+
+		#LOC.ftnm_bl40n_description = Advanced, compact spherical outflow reactor design. The BL-40-N is designed for multiple mission roles, and is designed to be used alone or in clusters.
+		#LOC.ftnm_bl40n_title = BL-40-N Nuclear Rocket
+
+		// ********** Part: ftmn180
+
+		#LOC.ftnm_ftmn180_description = The FTmN 180 is the pinnacle of classic reactor design. The engine was designed with modularity in mind, and Nucleotronics are hard at work developing thrust augmentation & power-generating turbine packs for all your future modular nuclear rocket system needs.
+		#LOC.ftnm_ftmn180_title = FTmN 180 Nuclear Rocket
+
+		// ********** Part: ftmn400
+
+		#LOC.ftnm_ftmn400_description = The goal of this engine is to provide something enormous to stick on the end of very big spacecraft. It houses a reactor capable of powering (or in unfortunate cases, rendering uninhabitable) a small city, has doubled-up turbopumps to aid in looking impressive and an exhaust manifold that may have been chosen simply because it looks like one off an especially large rocket engine.
+		#LOC.ftnm_ftmn400_title = FTmN 400 Nuclear Rocket
+
+		// ********** Part: ftmn80
+
+		#LOC.ftnm_ftmn80_description = The Fission Thermal Nuclear Rocket 80 was the fist in a long line of nuclear engines. Notable features include the worryingly lacking radiation shielding and the core design optimised for usage of typical liquid fuel, offering great thrust with modest Isp.
+		#LOC.ftnm_ftmn80_title = FTmN 80 Nuclear Rocket
+	}
+}

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_bl40n/bl40n_config.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_bl40n/bl40n_config.cfg
@@ -83,14 +83,14 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 25800
-	cost = 4400
+	entryCost = 13000
+	cost = 4100
 	
 	category = Propulsion
 	subcategory = 0
-	title = BL-40-N
-	manufacturer = Nucleotronics Inc.
-	description = Advanced, compact spherical outflow reactor design. The BL-40-N is designed for multiple mission roles, and is designed to be used alone or in clusters.
+	title = #LOC.ftnm_bl40n_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_bl40n_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0
@@ -126,7 +126,7 @@ PART
 		ignitionThreshold = 0.1
 		minThrust = 0
 		maxThrust = 40
-		heatProduction = 170
+		heatProduction = 195
 
 		//fxOffset = 0, 0, 2.0
         //heatProduction = 215

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_ftmn180/ftmn180_config.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_ftmn180/ftmn180_config.cfg
@@ -82,15 +82,14 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 15225
-	cost = 8700
+	entryCost = 37000
+	cost = 11000
 	
 	category = Propulsion
 	subcategory = 0
-	title = FTmN 180
-	manufacturer = Nucleotronics Inc.
-	description = The FTmN 180 is the pinnacle of classic reactor design. The engine was designed with modularity in mind, and Nucleotronics are hard at work developing thrust augmentation & power-generating turbine packs for all your future modular nuclear rocket system needs.
-	Optimised surface area ratios provide optimal heat transfer and high efficiency in this engine, at the cost of slightly reduced fuel flow.
+	title = #LOC.ftnm_ftmn180_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ftmn180_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0
@@ -126,7 +125,7 @@ PART
 		ignitionThreshold = 0.1
 		minThrust = 0
 		maxThrust = 180
-		heatProduction = 730
+		heatProduction = 680
 		EngineType = Nuclear
 	
 		PROPELLANT

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_ftmn400/ftmn400_config.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_ftmn400/ftmn400_config.cfg
@@ -82,15 +82,14 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 25800
-	cost = 17200
+	entryCost = 58000
+	cost = 18200
 	
 	category = Propulsion
 	subcategory = 0
-	title = FTmN 400
-	manufacturer = Nucleotronics Inc.
-	description = The goal of this engine is to provide something enormous to stick on the end of very big spacecraft. It houses a reactor capable of powering (or in unfortunate cases, rendering uninhabitable) a small city, has doubled-up turbopumps to aid in looking impressive and an exhaust manifold that may have been chosen simply because it looks like one off an especially large rocket engine.
-	
+	title = #LOC.ftnm_ftmn400_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ftmn400_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0

--- a/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_ftmn80/ftmn80_config.cfg
+++ b/Release/GameData/SpaceTuxIndustries/RecycledParts/ftmn_new/parts/engine/n_ftmn80/ftmn80_config.cfg
@@ -83,14 +83,14 @@ PART
 	// -------- Editor ---------
 	
 	TechRequired = nuclearPropulsion
-	entryCost = 8200
-	cost = 4000
+	entryCost = 21200
+	cost = 6100
 	
 	category = Propulsion
 	subcategory = 0
-	title = FTmN 80
-	manufacturer = Nucleotronics Inc.
-	description = The Fission Thermal Nuclear Rocket 80 was the fist in a long line of nuclear engines. Notable features include the worryingly lacking radiation shielding and the core design optimised for usage of typical liquid fuel, offering great thrust with modest Isp.
+	title = #LOC.ftnm_ftmn80_title
+	manufacturer = #LOC.ftnm_manufacturer
+	description = #LOC.ftnm_ftmn80_description
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,0,0


### PR DESCRIPTION
- part files changed to localization strings (us-en)
- added german translation (de-de)
- except for Farscape parts folder, cheat mod/ very basic part infos/no descriptions
- minimal conspicuous part tweaks to fit within career/ stock game/ own mod competitor parts.

Tested with game languages: en-us, de-de, fr-fr