### PR TITLE
Hide the IntakeAtm resource.

### DIFF
--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/IntakeAtm.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/IntakeAtm.cfg
@@ -7,6 +7,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityResourcePack]
   flowMode = ALL_VESSEL
   transfer = PUMP
   isTweakable = false
+  isVisible = false
 }
 
 // This adds the modules to those parts which have both ModuleResourceIntake


### PR DESCRIPTION
Reduces clutter in the resources/fuels tab by hiding the IntakeAtm resource like the regular IntakeAir resource.