### PR TITLE
Atomic Age update

### DIFF
--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Localization/en-us.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Localization/en-us.cfg
@@ -28,17 +28,17 @@ Localization
 
 		// ********** Part: radiatorRadialLarge
 
-		#LOC.aa_radiatorRadialLarge_description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 300
-		#LOC.aa_radiatorRadialLarge_title = Wrap-Around Radiator (3.75m)
+		#LOC.aa_radiatorRadialLarge_description = High performance, wrap-around, Titanium radiator with molten Lithium active cooling cycle. Highly temperature resistant and extremely durable. Fits 3.75m body. Do not attempt to use this to grill snacks.
+		#LOC.aa_radiatorRadialLarge_title = WRS3-1920 High Temperature Radiator
 
 		// ********** Part: radiatorRadialMedium
 
-		#LOC.aa_radiatorRadialMedium_description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 125
-		#LOC.aa_radiatorRadialMedium_title = Wrap-Around Radiator (2.5m)
+		#LOC.aa_radiatorRadialMedium_description = High performance, wrap-around, Titanium radiator with molten Lithium active cooling cycle. Highly temperature resistant and extremely durable. Fits 2.5m body. Do not attempt to use this to grill snacks.
+		#LOC.aa_radiatorRadialMedium_title = WRS2-620 High Temperature Radiator
 
 		// ********** Part: radiatorRadialSmall
 
-		#LOC.aa_radiatorRadialSmall_description = High performance titanium radiator with molten lithium active cooling cycle. Highly temperature resistant and extremely durable. Power Rating: 60
-		#LOC.aa_radiatorRadialSmall_title = Wrap-Around Radiator (1.25m)
+		#LOC.aa_radiatorRadialSmall_description = High performance, wrap-around, Titanium radiator with molten Lithium active cooling cycle. Highly temperature resistant and extremely durable. Fits 1.25m body. Do not attempt to use this to grill snacks.
+		#LOC.aa_radiatorRadialSmall_title = WRS1-230 High Temperature Radiator
 	}
 }

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialLarge.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialLarge.cfg
@@ -8,19 +8,19 @@ PART
 		model = SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialLarge
 	}
 	rescaleFactor = 1
-	node_stack_top = 0, 1.875, -0.1875, 0, 1, 0, 2
-	node_stack_bottom = 0,-1.875, -0.1875, 0, -1, 0, 2
+	node_stack_top = 0, 1.875, -0.1875, 0, 1, 0, 1
+	node_stack_bottom = 0, -1.875, -0.1875, 0, -1, 0, 1
 	node_attach = 0.0, -1.875, 0.05, 0.0, 0.0, -1.0
 	TechRequired = nuclearPropulsion
 	entryCost = 4500
-	cost = 1250
+	cost = 14621
 	category = Thermal
 	subcategory = 0
 	title = #LOC.aa_radiatorRadialLarge_title
 	manufacturer = #LOC.aa_atomicage_manufacturer
 	description = #LOC.aa_radiatorRadialLarge_description
-	attachRules = 0,1,0,1,1
-	mass = 0.075
+	attachRules = 1,1,1,1,1
+	mass = 1.625
 	thermalMassModifier = 1
 	radiatorHeadroom = 0.85
 	skinInternalConductionMult = 2000
@@ -31,10 +31,10 @@ PART
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 2
-	crashTolerance = 12
-	breakingForce = 200
-	breakingTorque = 200
-maxTemp = 2500 // 2000
+	crashTolerance = 20
+	breakingForce = 500
+	breakingTorque = 500
+	maxTemp = 2500 // 2000
 	thermalMassModifier = 5.0 // 1.0 // 5.0 = stock
 	skinInternalConductionMult = 2000 // 2000 = stock
 	skinSkinConductionMult = 0.001
@@ -42,27 +42,25 @@ maxTemp = 2500 // 2000
 	emissiveConstant = 0.95 // 0.90 = stock
 	radiatorHeadroom = 0.85 // 0.75 = stock
 	fuelCrossFeed = False
-
-	bulkheadProfiles = srf // size0, srf
-	tags = #autoLOC_500798
+	bulkheadProfiles = srf
+	tags = cool fixed heat moderat radiat static temperat therm wrap around pork //#autoLOC_500798 = cool fixed heat moderat radiat static temperat therm
 
 	MODULE
 	{
 		name = ModuleActiveRadiator
-		maxEnergyTransfer = 25000
+		maxEnergyTransfer = 96000
 		overcoolFactor = 0.25
 		isCoreRadiator = true
-		parentCoolingOnly = true
 		RESOURCE
 		{
 			name = ElectricCharge
-			rate = 0.025
+			rate = 0.24
 		}
 	}
 
 	MODULE
 	{
-      		name = ModuleAnimateHeat
-     		ThermalAnim = RadiatorRadialHeat
+		name = ModuleAnimateHeat
+		ThermalAnim = RadiatorRadialHeat
 	}
 }

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialMedium.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialMedium.cfg
@@ -9,18 +9,18 @@ PART
 	}
 	rescaleFactor = 1
 	node_stack_top = 0, 1.25, -0.125, 0, 1, 0, 1
-	node_stack_bottom = 0,-1.25, -0.125, 0, -1, 0, 1
+	node_stack_bottom = 0, -1.25, -0.125, 0, -1, 0, 1
 	node_attach = 0.0, -1.25, 0.033, 0.0, 0.0, -1.0
 	TechRequired = nuclearPropulsion
 	entryCost = 3000
-	cost = 650
+	cost = 2592
 	category = Thermal
 	subcategory = 0
 	title = #LOC.aa_radiatorRadialMedium_title
 	manufacturer = #LOC.aa_atomicage_manufacturer
 	description = #LOC.aa_radiatorRadialMedium_description
-	attachRules = 0,1,0,1,1
-	mass =  0.045
+	attachRules = 1,1,1,1,1
+	mass = 0.288
 	thermalMassModifier = 1
 	radiatorHeadroom = 0.85
 	skinInternalConductionMult = 2000
@@ -31,9 +31,9 @@ PART
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 2
-	crashTolerance = 12
-	breakingForce = 200
-	breakingTorque = 200
+	crashTolerance = 20
+	breakingForce = 500
+	breakingTorque = 500
 	maxTemp = 2500
 	thermalMassModifier = 5.0 // 1.0 // 5.0 = stock
 	skinInternalConductionMult = 2000 // 2000 = stock
@@ -42,26 +42,25 @@ PART
 	emissiveConstant = 0.95 // 0.90 = stock
 	radiatorHeadroom = 0.85 // 0.75 = stock
 	fuelCrossFeed = False
-	bulkheadProfiles = srf // size0, srf
-	tags = #autoLOC_500798 //#autoLOC_500798 = cool fixed heat moderat radiat static temperat therm
+	bulkheadProfiles = srf
+	tags = cool fixed heat moderat radiat static temperat therm wrap around pork //#autoLOC_500798 = cool fixed heat moderat radiat static temperat therm
 
 	MODULE
 	{
 		name = ModuleActiveRadiator
-		maxEnergyTransfer = 10000
+		maxEnergyTransfer = 31000
 		overcoolFactor = 0.25
 		isCoreRadiator = true
-		parentCoolingOnly = true
 		RESOURCE
 		{
 			name = ElectricCharge
-			rate = 0.025
+			rate = 0.08
 		}
 	}
 
 	MODULE
 	{
-      		name = ModuleAnimateHeat
-     		ThermalAnim = RadiatorRadialHeat
+		name = ModuleAnimateHeat
+		ThermalAnim = RadiatorRadialHeat
 	}
 }

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialSmall.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Radiators/RadialSmall.cfg
@@ -9,18 +9,18 @@ PART
 	}
 	rescaleFactor = 1
 	node_stack_top = 0, 0.625, -0.0625, 0, 1, 0, 0
-	node_stack_bottom = 0,-0.625, -0.0625, 0, -1, 0, 0
+	node_stack_bottom = 0, -0.625, -0.0625, 0, -1, 0, 0
 	node_attach = 0.0, -0.625, 0.016, 0.0, 0.0, -1.0
 	TechRequired = nuclearPropulsion
 	entryCost = 2500
-	cost = 250
+	cost = 545
 	category = Thermal
 	subcategory = 0
 	title = #LOC.aa_radiatorRadialSmall_title
 	manufacturer = #LOC.aa_atomicage_manufacturer
 	description = #LOC.aa_radiatorRadialSmall_description
-	attachRules = 0,1,0,1,1 
-	mass = 0.025
+	attachRules = 1,1,1,1,1
+	mass = 0.061
 	thermalMassModifier = 1
 	radiatorHeadroom = 0.85
 	skinInternalConductionMult = 2000
@@ -31,9 +31,9 @@ PART
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 2
-	crashTolerance = 12
-	breakingForce = 200
-	breakingTorque = 200
+	crashTolerance = 20
+	breakingForce = 500
+	breakingTorque = 500
 	maxTemp = 2500 // 2000
 	thermalMassModifier = 5.0 // 1.0 // 5.0 = stock
 	skinInternalConductionMult = 2000 // 2000 = stock
@@ -41,30 +41,27 @@ PART
 	heatConductivity = 0.001 // 0.001 = stock
 	emissiveConstant = 0.95 // 0.90 = stock
 	radiatorHeadroom = 0.85 // 0.75 = stock
-
 	fuelCrossFeed = False
-
-	bulkheadProfiles = srf // size0, srf
-	tags = #autoLOC_500798 //#autoLOC_500798 = cool fixed heat moderat radiat static temperat therm
+	bulkheadProfiles = srf
+	tags = cool fixed heat moderat radiat static temperat therm wrap around pork //#autoLOC_500798 = cool fixed heat moderat radiat static temperat therm
 
 	MODULE
 	{
 		name = ModuleActiveRadiator
-		maxEnergyTransfer = 5000
+		maxEnergyTransfer = 11500
 		overcoolFactor = 0.25
 		isCoreRadiator = true
-		parentCoolingOnly = true
 		RESOURCE
 		{
 			name = ElectricCharge
-			rate = 0.025
+			rate = 0.03
 		}
 	}
 
 	MODULE
 	{
-      		name = ModuleAnimateHeat
-     		ThermalAnim = RadiatorRadialHeat
+		name = ModuleAnimateHeat
+		ThermalAnim = RadiatorRadialHeat
 	}
 }
 

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Turbojet-5/TuboJet-5.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Turbojet-5/TuboJet-5.cfg
@@ -160,7 +160,7 @@ PART
 		}
 		atmosphereCurve
 		{
-			key = 0 8000 0 0
+			key = 0 3000
 		}
 		// Jet params
 		atmChangeFlow = True
@@ -175,7 +175,6 @@ PART
 			key = 0 1 0 -0.01591885
 			key = 1 0.85 -0.3977894 -0.3977894
 			key = 4 0 0 0
-
 		}
 		atmCurve
 		{

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Turbojet-5/TuboJet-5.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Parts/Turbojet-5/TuboJet-5.cfg
@@ -129,7 +129,7 @@ PART
 		ignitionThreshold = 0.1
 		minThrust = 0
 		maxThrust = 105
-		heatProduction = 430
+		heatProduction = 140
 		useEngineResponseTime = True
 		engineAccelerationSpeed = 0.12
 		engineDecelerationSpeed = 0.5

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/KANDL.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/KANDL.cfg
@@ -1,0 +1,128 @@
+@PART[nuclearEngineKANDL]:NEEDS[Waterfall]
+{
+  !fx_exhaustFlame_blue = DELETE
+  !fx_exhaustLight_blue = DELETE
+  !fx_smokeTrail_light = DELETE
+  !sound_vent_medium = DELETE
+  !sound_rocket_hard = DELETE
+  !sound_vent_soft = DELETE
+  !sound_explosion_low = DELETE
+  // Removes the stock effect block, and replace it with one that has no particles
+  !EFFECTS {}
+  EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_liq7
+                volume = 0.6
+                pitch = 0.7
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 1.0
+                pitch = 0.7
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 1.0
+                pitch = 0.7
+                loop = false
+            }
+        }
+		fx-nerv-running
+		{
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_rocket_hard
+                volume = 0.0 0.0
+                volume = 0.01 0.1
+                volume = 0.5 0.35
+                volume = 1.0 0.7
+                pitch = 0.0 0.5
+                pitch = 1.0 0.7
+                loop = true
+            }
+        }
+    }
+  
+  @MODULE[ModuleEngines*]
+   {
+    @name = ModuleEnginesFX
+	%runningEffectName = fx-nerv-running
+   }
+  
+  MODULE
+  {
+    name = ModuleWaterfallFX
+    moduleID = nukeFX
+
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+	  engineID = basicEngine
+	  responseRateUp = 0.03
+      responseRateDown = 0.2
+    }
+	
+	CONTROLLER
+	{
+		name = random1
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 8
+		seed = 15
+	}
+	CONTROLLER
+	{
+		name = random2
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 10
+		seed = 15
+	}
+	
+   TEMPLATE
+    {
+      templateName = ntr_swe
+      overrideParentTransform = thrustTransform
+      scale = 0.25,0.25,0.25
+      rotation = 0,0,0
+      position = 0,0,-0.19
+    }
+	
+   TEMPLATE
+    {
+      templateName = ntr_core_swe
+      overrideParentTransform = thrustTransform
+      scale = 0.25,0.25,0.25
+      rotation = 0,0,0
+      position = 0,0,-0.19
+    }
+  }
+}

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/LANTR.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/LANTR.cfg
@@ -1,0 +1,128 @@
+@PART[nuclearEngineLANTR]:NEEDS[Waterfall]
+{
+  !fx_exhaustFlame_blue = DELETE
+  !fx_exhaustLight_blue = DELETE
+  !fx_smokeTrail_light = DELETE
+  !sound_vent_medium = DELETE
+  !sound_rocket_hard = DELETE
+  !sound_vent_soft = DELETE
+  !sound_explosion_low = DELETE
+  // Removes the stock effect block, and replace it with one that has no particles
+  !EFFECTS {}
+  EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_liq7
+                volume = 0.6
+                pitch = 0.7
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 1.0
+                pitch = 0.7
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 1.0
+                pitch = 0.7
+                loop = false
+            }
+        }
+		fx-nerv-running
+		{
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_rocket_hard
+                volume = 0.0 0.0
+                volume = 0.01 0.1
+                volume = 0.5 0.35
+                volume = 1.0 0.7
+                pitch = 0.0 0.5
+                pitch = 1.0 0.7
+                loop = true
+            }
+        }
+    }
+  
+  @MODULE[ModuleEngines*]
+   {
+    @name = ModuleEnginesFX
+	%runningEffectName = fx-nerv-running
+   }
+  
+  MODULE
+  {
+    name = ModuleWaterfallFX
+    moduleID = nukeFX
+
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+	  engineID = basicEngine
+	  responseRateUp = 0.03
+      responseRateDown = 0.2
+    }
+	
+	CONTROLLER
+	{
+		name = random1
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 8
+		seed = 15
+	}
+	CONTROLLER
+	{
+		name = random2
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 10
+		seed = 15
+	}
+	
+   TEMPLATE
+    {
+      templateName = ntr_swe
+      overrideParentTransform = thrustTransform
+      scale = 0.65,0.65,0.65
+      rotation = 0,0,0
+      position = 0,0,-0.9
+    }
+	
+   TEMPLATE
+    {
+      templateName = ntr_core_swe
+      overrideParentTransform = thrustTransform
+      scale = 0.65,0.65,0.65
+      rotation = 0,0,0
+      position = 0,0,-0.9
+    }
+  }
+}

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/LBULB.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/LBULB.cfg
@@ -1,0 +1,128 @@
+@PART[nuclearEngineLightbulb]:NEEDS[Waterfall]
+{
+  !fx_exhaustFlame_blue = DELETE
+  !fx_exhaustLight_blue = DELETE
+  !fx_smokeTrail_light = DELETE
+  !sound_vent_medium = DELETE
+  !sound_rocket_hard = DELETE
+  !sound_vent_soft = DELETE
+  !sound_explosion_low = DELETE
+  // Removes the stock effect block, and replace it with one that has no particles
+  !EFFECTS {}
+  EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_liq7
+                volume = 0.6
+                pitch = 0.7
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 1.0
+                pitch = 0.7
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 1.0
+                pitch = 0.7
+                loop = false
+            }
+        }
+		fx-nerv-running
+		{
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_rocket_hard
+                volume = 0.0 0.0
+                volume = 0.01 0.1
+                volume = 0.5 0.35
+                volume = 1.0 0.7
+                pitch = 0.0 0.5
+                pitch = 1.0 0.7
+                loop = true
+            }
+        }
+    }
+  
+  @MODULE[ModuleEngines*]
+   {
+    @name = ModuleEnginesFX
+	%runningEffectName = fx-nerv-running
+   }
+  
+  MODULE
+  {
+    name = ModuleWaterfallFX
+    moduleID = nukeFX
+
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+	  engineID = basicEngine
+	  responseRateUp = 0.03
+      responseRateDown = 0.2
+    }
+	
+	CONTROLLER
+	{
+		name = random1
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 8
+		seed = 15
+	}
+	CONTROLLER
+	{
+		name = random2
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 10
+		seed = 15
+	}
+	
+   TEMPLATE
+    {
+      templateName = ntr_swe
+      overrideParentTransform = thrustTransform
+      scale = 0.57,0.57,0.57
+      rotation = 0,0,0
+      position = 0,0,-0.5
+    }
+	
+   TEMPLATE
+    {
+      templateName = ntr_core_swe
+      overrideParentTransform = thrustTransform
+      scale = 0.57,0.57,0.57
+      rotation = 0,0,0
+      position = 0,0,-0.5
+    }
+  }
+}

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/NTJ.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/NTJ.cfg
@@ -1,0 +1,63 @@
+@PART[NuclearJetEngine]:AFTER[Waterfall]
+{
+  // Removes the stock effect block, and replace it with one that has no particles
+  !EFFECTS {}
+  EFFECTS
+  {		
+		fx-panther-wet-running
+		{
+            AUDIO
+            {
+                name = soundWet3
+                channel = Ship
+                clip = sound_jet_deep
+                volume = 0.1 0.0
+                volume = 0.3 1.12
+                volume = 1.0 1.25
+                pitch = 0.0 0.4
+                pitch = 1.0 1.0
+                loop = true
+            }
+		}
+  }
+	
+@MODULE[ModuleEngines*]
+	{
+	%runningEffectName = fx-panther-wet-running
+	!powerEffectName = DELETE
+	!spoolEffectName = DELETE
+	}
+  
+MODULE
+  {
+    name = ModuleWaterfallFX
+    moduleID = pantherWet
+    
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    CONTROLLER
+    {
+      name = throttle
+	  linkedTo = throttle
+	  engineID = Wet
+	  responseRateUp = 0.001
+      responseRateDown = 0.016
+    }
+	CONTROLLER
+	{
+		name = mach
+		linkedTo = mach
+	}
+    TEMPLATE
+    {
+      templateName = ntj_toxicgreen
+      overrideParentTransform = thrustTransform
+      position = 0,0,0
+      rotation = 0, 0, 0
+      scale = 1, 1, 1
+    }
+  }
+}

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/template_ntj_toxicgreen.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/template_ntj_toxicgreen.cfg
@@ -1,0 +1,3208 @@
+EFFECTTEMPLATE:NEEDS[Waterfall]
+{
+	templateName = ntj_toxicgreen
+	EFFECT
+	{
+		name = refraction
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.449999988
+			rotationOffset = -90,0,0
+			scaleOffset = 0.600000024,25,0.600000024
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Distortion (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _DistortionTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _Highlight
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 10
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = -3
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.229222342
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Strength
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Swirl
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.800000012
+				}
+				FLOAT
+				{
+					floatName = _Blur
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.78 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.6 0 0
+				key = 1 1.3 0 0
+			}
+			zCurve
+			{
+				key = 0 0.78 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = mScale
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.33
+				key = 3 2 0.33 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTileY
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileY
+			floatCurve
+			{
+				key = 0 8 0 4
+				key = 1 12 4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tStrength
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Strength
+			floatCurve
+			{
+				key = 0 0 0 3
+				key = 0.1 0.15 0.4 0.4
+				key = 1 0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aStrength
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Strength
+			floatCurve
+			{
+				key = 0 0 0 0.5
+				key = 0.7 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = plume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.0700000003
+			rotationOffset = -90,0,0
+			scaleOffset = 0.395000011,11,0.395000011
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.400000006,0.941176474,0.105882354,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.239215687,0.600000024,0.0431372561,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.000300000014
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.00666572154
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.813943148
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.29999995
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 160
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1.5
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 25
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.805554867
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.0199999996
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = mScale
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.2
+				key = 3 1.6 0.2 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 10
+				key = 0.1 0.8 1 1
+				key = 1 1.1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 10 0 -9
+				key = 1 1.3 -9 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.1 0 0 10
+				key = 0.4 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tFadeout
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _FadeOut
+			floatCurve
+			{
+				key = 0 1 0 -0.6
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = ADD
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.8 0 -3 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0.5
+				key = 3 0.5 -0.4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tNoise
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Noise
+			floatCurve
+			{
+				key = 0 0.5 0 2
+				key = 1 4 2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = edgePlume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.0700000003
+			rotationOffset = -90,0,0
+			scaleOffset = 0.395000011,11,0.395000011
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.964705884,0.972549021,0.0470588244,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.701960802,0.70588237,0.0705882385,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.000300000014
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.5
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.764611185
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.29999995
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.5474968
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.150000006
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.173611313
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = mScale
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.2
+				key = 3 1.6 0.2 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 50
+				key = 0.1 2.5 4 4
+				key = 1 4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 10 0 -8
+				key = 1 2.2 -8 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.1 0 0 10
+				key = 0.4 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tFadeout
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _FadeOut
+			floatCurve
+			{
+				key = 0 1 0 -0.2
+				key = 1 0.9 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = ADD
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.8 0 -3 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0.5
+				key = 3 0.4 -0.4 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.300000012
+			rotationOffset = -90,0,0
+			scaleOffset = 0.150000006,0.600000024,0.150000006
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.15
+				key = 3 -0.5 -0.15 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,1.10000002
+			rotationOffset = -90,0,0
+			scaleOffset = 0.150000006,0.600000024,0.150000006
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.2
+				key = 3 -1.225 -0.2 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.05 0 0 0
+				key = 1 0.75 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.05 10 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock3
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,1.89999998
+			rotationOffset = -90,0,0
+			scaleOffset = 0.150000006,0.600000024,0.150000006
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.65
+				key = 3 -1.95 -0.65 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.15 0 0 0
+				key = 1 0.6 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.15 10 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock4
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2.70000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.150000006,0.600000024,0.150000006
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.9
+				key = 3 -2.8 -0.9 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.3 0 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.3 10 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock5
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,3.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.150000006,0.600000024,0.150000006
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.15
+				key = 3 -3.65 -1.15 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.475 0 0 0
+				key = 1 0.4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.475 10 0 0
+				key = 1 3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock6
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,4.30000019
+			rotationOffset = -90,0,0
+			scaleOffset = 0.150000006,0.600000024,0.150000006
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.4
+				key = 3 -4.5 -1.4 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.55 0 0 0
+				key = 1 0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.55 10 0 0
+				key = 1 4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock7
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,5.0999999
+			rotationOffset = -90,0,0
+			scaleOffset = 0.140000001,0.600000024,0.140000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.66
+				key = 3 -5.35 -1.66 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.6 0 0 0
+				key = 1 0.2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.6 10 0 0
+				key = 1 5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock8
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,5.9000001
+			rotationOffset = -90,0,0
+			scaleOffset = 0.129999995,0.600000024,0.129999995
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.9
+				key = 3 -6.2 -1.9 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.65 0 0 0
+				key = 1 0.15 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.65 10 0 0
+				key = 1 6 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock9
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,6.69999981
+			rotationOffset = -90,0,0
+			scaleOffset = 0.119999997,0.600000024,0.119999997
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -2.1
+				key = 3 -7.05 -2.1 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.7 0 0 0
+				key = 1 0.1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.7 10 0 0
+				key = 1 7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock10
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,7.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.100000001,0.600000024,0.100000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -2.5
+				key = 3 -7.9 -2.5 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.75 10 0 0
+				key = 1 7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.75 0 0 0
+				key = 1 0.06 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock11
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,8.30000019
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0900000036,0.600000024,0.0900000036
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.842778802
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = mPos
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -2.4
+				key = 3 -8.75 -2.4 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.8 0 0 0
+				key = 1 0.06 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.8 10 0 0
+				key = 1 5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = core
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.870000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.280000001,0.802999973,0.280000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0862745121,0.874509811,0.141176477,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.0235294122,0.454901963,0.0549019612,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.222000003
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.00300000003
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 140
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.705554783
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.5
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 10
+				key = 0.1 0.42 1 1
+				key = 1 0.92 0.5 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.09 0 0 7
+				key = 0.45 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.1 0 0 5
+				key = 1 20 20 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0.7
+				key = 3 0.5 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = edgeCore
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.870000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.280000001,0.802999973,0.280000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0627451017,0.792156875,0.117647059,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.0274509806,0.513725519,0.0627451017,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.222000003
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.00300000003
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.25722122
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 30
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 140
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2.32555199
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.5
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.701666415
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 30
+				key = 0.1 2.5 20 20
+				key = 1 17 50 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.1 0 0 5
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tTintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0.1 0 0 5
+				key = 1 20 20 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = mBright
+			controllerName = mach
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0.7
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+}

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/template_ntr_core_swe.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/template_ntr_core_swe.cfg
@@ -1,0 +1,250 @@
+EFFECTTEMPLATE:NEEDS[Waterfall]
+{
+	templateName = ntr_core_swe
+	EFFECT
+	{
+		name = core1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = -0.00164999999,-0.00144999998,-0.180999994
+			rotationOffset = -90,0,0
+			scaleOffset = 0.00100000005,1.01999998,0.00100000005
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-4
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.319379747,0.532840014,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.35221982,0.671599507,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 422
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.0198889002
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.252777398
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.960554302
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.55611014
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 1.36499774
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 200
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 5
+				key = 1 1.55 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = core2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-simple-plume-1
+			positionOffset = 0,0,-0.0199999996
+			rotationOffset = -90,0,0
+			scaleOffset = 1,0.0900000036,1
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-4
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.30295974,0.442529917,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.331865788,0.515609264,1
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.31444275
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.10055548
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 4.09499359
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.62582588
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 200
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 1
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = ThroatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.08 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.08 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = ExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.09 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.09 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = TailScale
+			controllerName = throttle
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.7 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0.33
+				key = 1 0.1 0 0
+			}
+		}
+	}
+}

--- a/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/template_ntr_swe.cfg
+++ b/GameData/SpaceTuxIndustries/RecycledParts/AtomicAge/Waterfall/template_ntr_swe.cfg
@@ -1,0 +1,1159 @@
+EFFECTTEMPLATE:NEEDS[Waterfall]
+{
+	templateName = ntr_swe
+	EFFECT
+	{
+		name = coreFlame
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.819999993
+			rotationOffset = -90,0,0
+			scaleOffset = 0.416000009,15,0.416000009
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-4
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.188019544,0.417899936,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.67241019,0,0.270119637,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = -0.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 7.68443251
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.47415972
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 152.666428
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.758332193
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.01722693
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.545000732
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aScale
+			controllerName = atmosphereDepth
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.416 0 0
+			}
+			yCurve
+			{
+				key = 0 15 0 0
+				key = 0.2 20 0 0
+				key = 1 8 0 0
+			}
+			zCurve
+			{
+				key = 0 0.416 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBounded
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 2 0 -25
+				key = 0.35 -0.5 0 0
+				key = 1 -0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 30 0 -80
+				key = 0.4 7.7 0 0
+				key = 1 7.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aTintFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.4 1.5 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 1.8
+				key = 1 0.7 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = OuterFlame
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.819999993
+			rotationOffset = -90,0,0
+			scaleOffset = 0.416000009,40,0.416000009
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.25369966,0,0.0648693591,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.196229532,0.319379717,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.3144424
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 2.17388582
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.621832371
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 9.02415276
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 41.355648
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.556110203
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.27499628
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.600000024
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 24.2666283
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aScale
+			controllerName = atmosphereDepth
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 1 0.416 0 0
+			}
+			yCurve
+			{
+				key = 0 40 0 0
+				key = 0.4 40 0 0
+				key = 1 20 0 0
+			}
+			zCurve
+			{
+				key = 1 0.416 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBounded
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 12 0 -50
+				key = 0.4 1.3 -5 -5
+				key = 1 -0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 30 0 -200
+				key = 0.3 2.17 0 0
+				key = 1 2.17 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aNoise
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Noise
+			floatCurve
+			{
+				key = 0 3 0 10
+				key = 0.45 9 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 4 0 -8
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 1.6
+				key = 1 0.56 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = exitTraces1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.819999993
+			rotationOffset = -90,0,0
+			scaleOffset = 0.416000009,15,0.416000009
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.245489627,0.442529917,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.270119637,0.557470083,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 30
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.09499359
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 87.9665298
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.623055816
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.342778862
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBounded
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 5 0 -20
+				key = 0.4 0 -1 -1
+				key = 1 -0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.6 0 0
+				key = 0.5 0.34 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aTintFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TintFalloff
+			floatCurve
+			{
+				key = 0 2 0 0
+				key = 0.4 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 3.5
+				key = 1 1.3 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = exitTraces2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.819999993
+			rotationOffset = -90,0,0
+			scaleOffset = 0.416000009,15,0.416000009
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-3
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.590310156,0.762720346,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.532840014,0.738090336,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 70
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.09499359
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 100
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.443889827
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBounded
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 6 0 -30
+				key = 0.4 0 -2 -2
+				key = 1 -1.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 1.5
+				key = 1 0.55 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.949999988
+			rotationOffset = -90,0,0
+			scaleOffset = 0.100000001,0.699999988,0.100000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.532839954,0.746300399,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.92610991,0.753699601,0.909689844,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.5
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 3.79999995
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.19417095
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 200
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.0299999993
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 45
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aPos
+			controllerName = atmosphereDepth
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0.2 1.25 0 -0.5
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.2 0 0 0.5
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aLinear
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0.2 1 0 -5
+				key = 0.7 -1.1 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = tPos
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0.3 0 -0.3
+				key = 1 0 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 2
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random1
+			randomnessScale = 0.0250000004
+			xCurve
+			{
+				key = 0 0.13 0 0
+				key = 1 0.1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 0.7 0 0
+			}
+			zCurve
+			{
+				key = 0 0.13 0 0
+				key = 1 0.1 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = rPos
+			controllerName = random2
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = ADD
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = -0.5 -0.01 0 0.02
+				key = 0.5 0.01 0.02 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = light
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-point-light
+			positionOffset = 0,0,0.600000024
+			rotationOffset = 0,0,0
+			scaleOffset = 1,1,1
+			LIGHT
+			{
+				transform = Light
+				intensity = 0.5
+				range = 8
+				lightType = Point
+				color = 0.844009757,0.499189228,0.745489538,1
+				angle = 0
+			}
+		}
+		LIGHTFLOATMODIFIER
+		{
+			name = tIntensity
+			controllerName = throttle
+			transformName = Light
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = Intensity
+			floatCurve
+			{
+				key = 0 0 0 2
+				key = 0.2 0.22 0.5 0.5
+				key = 1 0.45 0 0
+			}
+		}
+		LIGHTFLOATMODIFIER
+		{
+			name = aRange
+			controllerName = atmosphereDepth
+			transformName = Light
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = Range
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 0.2 14 0 0
+				key = 1 10 0 0
+			}
+		}
+		LIGHTFLOATMODIFIER
+		{
+			name = rIntensity
+			controllerName = random1
+			transformName = Light
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = Intensity
+			floatCurve
+			{
+				key = -0.5 0.85 0 0.3
+				key = 0.5 1.15 0.3 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = refraction
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.819999993
+			rotationOffset = -90,0,0
+			scaleOffset = 0.416000009,20,0.416000009
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Distortion (Dynamic)
+				randomizeSeed = True
+				FLOAT
+				{
+					floatName = _Highlight
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.150000006
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.200000003
+				}
+				TEXTURE
+				{
+					textureSlotName = _DistortionTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _Strength
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 8
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 16.9891644
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Blur
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Swirl
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aScale
+			controllerName = atmosphereDepth
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.416 0 0
+			}
+			yCurve
+			{
+				key = 0 6 0 200
+				key = 0.4 40 0 0
+				key = 1 20 0 0
+			}
+			zCurve
+			{
+				key = 0 0.416 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBounded
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 3 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aStrength
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Strength
+			floatCurve
+			{
+				key = 0 0.03 0 0.15
+				key = 1 0.12 0.2 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aTileY
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileY
+			floatCurve
+			{
+				key = 0 3 0 30
+				key = 0.5 8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aSpeedY
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _SpeedY
+			floatCurve
+			{
+				key = 0 40 0 -200
+				key = 0.3 15 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tStrength
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Strength
+			floatCurve
+			{
+				key = 0 0 0 8
+				key = 0.1 0.4 1 1
+				key = 1 1 0 0
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Radiators
* Raised their costs, masses, capacities and ElectricCharge demands to compare well with Nertea's Heat Control.
* Disabled parent cooling only so they're effective from anywhere on vessel.
* Updated titles and descriptions.
![spreadsheet comparison](https://i.imgur.com/BvXRoAu.png)

## Nuclear jet
* Decreased Isp so it requires more air. It's extremely efficient just by handling IntakeAtm, but it can't be that efficient with IntakeAtm itself.
* Decreased heat production so it doesn't threaten to overheat so soon.

## Waterfall
* Waterfall configs for all engines. Contributed by [Hohmannson](https://github.com/hohmannson) (same name on GitHub and KSP forum). Derived from **Stock Waterfall Effects** by Knight of St John.